### PR TITLE
change vm func(args) to accept empty args

### DIFF
--- a/datasource/context.go
+++ b/datasource/context.go
@@ -165,7 +165,7 @@ func (m ContextUrlValues) Get(key string) (value.Value, bool) {
 		}
 		return value.NewValue(vals), true
 	}
-	return value.EmptyStringValue, false
+	return value.EmptyStringValue, true
 }
 func (m ContextUrlValues) Row() map[string]value.Value {
 	mi := make(map[string]value.Value)

--- a/datasource/context.go
+++ b/datasource/context.go
@@ -165,7 +165,7 @@ func (m ContextUrlValues) Get(key string) (value.Value, bool) {
 		}
 		return value.NewValue(vals), true
 	}
-	return value.EmptyStringValue, true
+	return value.EmptyStringValue, false
 }
 func (m ContextUrlValues) Row() map[string]value.Value {
 	mi := make(map[string]value.Value)

--- a/expr/builtins/builtins.go
+++ b/expr/builtins/builtins.go
@@ -140,10 +140,10 @@ func NotFunc(ctx expr.EvalContext, item value.Value) (value.BoolValue, bool) {
 func Gt(ctx expr.EvalContext, lv, rv value.Value) (value.BoolValue, bool) {
 	left := value.ToFloat64(lv.Rv())
 	right := value.ToFloat64(rv.Rv())
-	if left == math.NaN() || right == math.NaN() {
+
+	if math.IsNaN(left) || math.IsNaN(right) {
 		return value.BoolValueFalse, false
 	}
-
 	return value.NewBoolValue(left > right), true
 }
 
@@ -211,8 +211,29 @@ func Exists(ctx expr.EvalContext, item interface{}) (value.BoolValue, bool) {
 			return value.BoolValueTrue, true
 		}
 		return value.BoolValueFalse, true
-	case value.StringValue, value.BoolValue, value.NumberValue, value.StringsValue,
-		value.TimeValue, value.IntValue, value.SliceValue, value.MapIntValue:
+	case value.StringValue:
+		if node.Nil() {
+			return value.BoolValueFalse, true
+		}
+		return value.BoolValueTrue, true
+	case value.BoolValue:
+		return value.BoolValueTrue, true
+	case value.NumberValue:
+		if node.Nil() {
+			return value.BoolValueFalse, true
+		}
+		return value.BoolValueTrue, true
+	case value.IntValue:
+		if node.Nil() {
+			return value.BoolValueFalse, true
+		}
+		return value.BoolValueTrue, true
+	case value.TimeValue:
+		if node.Nil() {
+			return value.BoolValueFalse, true
+		}
+		return value.BoolValueTrue, true
+	case value.StringsValue, value.SliceValue, value.MapIntValue:
 		return value.BoolValueTrue, true
 	}
 	return value.BoolValueFalse, true

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -36,7 +36,7 @@ var (
 	// normally we would use time.Now()
 	//   "Apr 7, 2014 4:58:55 PM"
 	ts          = time.Date(2014, 4, 7, 16, 58, 55, 00, time.UTC)
-	readContext = datasource.NewContextUrlValuesTs(url.Values{"event": {"hello"}, "reg_date": {"10/13/2014"}, "price": {"$55"}}, ts)
+	readContext = datasource.NewContextUrlValuesTs(url.Values{"event": {"hello"}, "reg_date": {"10/13/2014"}, "price": {"$55"}, "email": {"email@email.com"}}, ts)
 	float3pt1   = float64(3.1)
 )
 
@@ -116,6 +116,8 @@ var builtinTests = []testBuiltins{
 	{`email("Bob@Bob.com")`, value.NewStringValue("bob@bob.com")},
 	{`email("Bob <bob>")`, value.ErrValue},
 	{`email("Bob <bob@bob.com>")`, value.NewStringValue("bob@bob.com")},
+	{`oneof(not_a_field, email("Bob <bob@bob.com>"))`, value.NewStringValue("bob@bob.com")},
+	{`oneof(email, email(not_a_field))`, value.NewStringValue("email@email.com")},
 
 	{`emailname("Bob<bob@bob.com>")`, value.NewStringValue("Bob")},
 
@@ -187,7 +189,7 @@ func TestBuiltins(t *testing.T) {
 		err = exprVm.Execute(writeContext, readContext)
 		if biTest.val.Err() {
 
-			assert.Tf(t, err != nil, "nil err: %v", err)
+			assert.Tf(t, err != nil, "%v  expected err: %v", biTest.expr, err)
 
 		} else {
 			tval := biTest.val

--- a/value/coerce.go
+++ b/value/coerce.go
@@ -385,7 +385,7 @@ func convertToFloat64(depth int, v reflect.Value) float64 {
 		item1 := v.Index(0)
 		u.Warnf("ToFloat() but is slice?: %T first=%v", v, item1)
 	default:
-		u.Warnf("Cannot convert type?  %v", v.Kind())
+		//u.Warnf("Cannot convert type?  %v", v.Kind())
 	}
 	return math.NaN()
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -97,6 +97,7 @@ func (m *Vm) Execute(writeContext expr.ContextWriter, readContext expr.ContextRe
 	s.rv = reflect.ValueOf(s)
 	//u.Debugf("vm.Execute:  %#v", m.Tree.Root)
 	v, ok := s.Walk(m.Tree.Root)
+	//u.Infof("v:%v  ok?%v", v, ok)
 	if ok && v != value.ErrValue {
 		// Special Vm that doesnt' have named fields, single tree expression
 		//u.Debugf("vm.Walk val:  %v", v)
@@ -479,7 +480,9 @@ func walkFunc(ctx expr.EvalContext, node *expr.FuncNode) (value.Value, bool) {
 			//u.Debugf("descending to %v()", t.Name)
 			v, ok = walkFunc(ctx, t)
 			if !ok {
-				return value.NewNilValue(), false
+				//return value.NewNilValue(), false
+				// nil arguments are valid
+				v = value.NewNilValue()
 			}
 			//u.Debugf("result of %v() = %v, %T", t.Name, v, v)
 			//v = extractScalar()
@@ -487,7 +490,9 @@ func walkFunc(ctx expr.EvalContext, node *expr.FuncNode) (value.Value, bool) {
 			//v = extractScalar(e.walkUnary(t))
 			v, ok = walkUnary(ctx, t)
 			if !ok {
-				return value.NewNilValue(), false
+				//return value.NewNilValue(), false
+				// nil arguments are valid ??
+				v = value.NewNilValue()
 			}
 		case *expr.BinaryNode:
 			//v = extractScalar(e.walkBinary(t))
@@ -516,13 +521,12 @@ func walkFunc(ctx expr.EvalContext, node *expr.FuncNode) (value.Value, bool) {
 
 	}
 	// Get the result of calling our Function (Value,bool)
-	//u.Debugf("Calling %v func:%v(%v)", node.F.F, node.F.Name, funcArgs)
+	//u.Debugf("Calling func:%v(%v) %v", node.F.Name, funcArgs, node.F.F)
 	fnRet := node.F.F.Call(funcArgs)
-	//u.Debugf("fnRet: %v", fnRet)
+	//u.Debugf("fnRet: %v    ok?%v", fnRet, fnRet[1].Bool())
 	// check if has an error response?
 	if len(fnRet) > 1 && !fnRet[1].Bool() {
 		// What do we do if not ok?
-		//u.Warnf("return false? ")
 		return value.EmptyStringValue, false
 	}
 	//u.Debugf("response %v %v  %T", node.F.Name, fnRet[0].Interface(), fnRet[0].Interface())


### PR DESCRIPTION
Previously certain types of arguments that could not be evaluated would pre-maturely return, allowing functions to return without evaluating.  

* ie, `oneof(email(not_a_field), "aaron@email.com")` would not be evaluated because email(not_a_field) would return preventing the rest of the function from evaluating.    
* What to do on arguments of a function that don't evaluate due to missing context-input is still a learning set of inputs