### PR TITLE
FilterQL improvements, support slices natively in parser

### DIFF
--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -99,6 +99,7 @@ var builtinTests = []testBuiltins{
 	{`tolower("Apple")`, value.NewStringValue("apple")},
 
 	{`join("apple", event, "oranges", "--")`, value.NewStringValue("apple--hello--oranges")},
+	{`join(["apple","peach"], ",")`, value.NewStringValue("apple,peach")},
 
 	{`split("apples,oranges",",")`, value.NewStringsValue([]string{"apples", "oranges"})},
 

--- a/expr/node.go
+++ b/expr/node.go
@@ -41,6 +41,7 @@ const (
 	IdentityNodeType    NodeType = 3
 	StringNodeType      NodeType = 4
 	NumberNodeType      NodeType = 5
+	ValueNodeType       NodeType = 8
 	BinaryNodeType      NodeType = 10
 	UnaryNodeType       NodeType = 11
 	TriNodeType         NodeType = 13
@@ -175,6 +176,13 @@ type NumberNode struct {
 	Int64   int64   // The integer value.
 	Float64 float64 // The floating-point value.
 	Text    string  // The original textual representation from the input.
+}
+
+// StringNode holds a value literal, quotes not included
+type ValueNode struct {
+	Pos
+	Value value.Value
+	rv    reflect.Value
 }
 
 // Binary node is   x op y, two nodes (left, right) and an operator
@@ -462,6 +470,15 @@ func (m *StringNode) StringAST() string   { return fmt.Sprintf("%q", m.Text) }
 func (m *StringNode) Check() error        { return nil }
 func (m *StringNode) NodeType() NodeType  { return StringNodeType }
 func (m *StringNode) Type() reflect.Value { return stringRv }
+
+func NewValueNode(pos Pos, val value.Value) *ValueNode {
+	return &ValueNode{Pos: pos, Value: val, rv: reflect.ValueOf(val)}
+}
+func (m *ValueNode) String() string      { return m.Value.ToString() }
+func (m *ValueNode) StringAST() string   { return m.Value.ToString() }
+func (m *ValueNode) Check() error        { return nil }
+func (m *ValueNode) NodeType() NodeType  { return ValueNodeType }
+func (m *ValueNode) Type() reflect.Value { return m.rv }
 
 func NewIdentityNode(tok *lex.Token) *IdentityNode {
 	return &IdentityNode{Pos: Pos(tok.Pos), Text: tok.V, Quote: tok.Quote}

--- a/expr/node.go
+++ b/expr/node.go
@@ -178,7 +178,8 @@ type NumberNode struct {
 	Text    string  // The original textual representation from the input.
 }
 
-// StringNode holds a value literal, quotes not included
+// Value holds a value.Value type
+//   value.Values can be strings, numbers, arrays, objects, etc
 type ValueNode struct {
 	Pos
 	Value value.Value

--- a/lex/dialect_filterql.go
+++ b/lex/dialect_filterql.go
@@ -96,8 +96,26 @@ func NewFilterQLLexer(input string) *Lexer {
 	return l
 }
 
+/*
+var SqlSelect = []*Clause{
+	{Token: TokenSelect, Lexer: LexSelectClause},
+	{Token: TokenInto, Lexer: LexIdentifierOfType(TokenTable), Optional: true},
+	{Token: TokenFrom, Lexer: LexTableReferences, Optional: true, Repeat: true, Clauses: sqlSubQuery},
+	{Token: TokenWhere, Lexer: LexConditionalClause, Optional: true, Clauses: sqlSubQuery},
+	{Token: TokenGroupBy, Lexer: LexColumns, Optional: true},
+	{Token: TokenHaving, Lexer: LexConditionalClause, Optional: true},
+	{Token: TokenOrderBy, Lexer: LexOrderByColumn, Optional: true},
+	{Token: TokenLimit, Lexer: LexNumber, Optional: true},
+	{Token: TokenWith, Lexer: LexJson, Optional: true},
+	{Token: TokenAlias, Lexer: LexIdentifier, Optional: true},
+	{Token: TokenEOF, Lexer: LexEndOfStatement, Optional: false},
+}
+*/
 var FilterStatement = []*Clause{
-	{Token: TokenFilter, Lexer: LexFilterClause, Optional: false},
+	{Token: TokenSelect, Lexer: LexSelectClause, Optional: true},
+	{Token: TokenFrom, Lexer: LexTableReferences, Optional: false},
+	{Token: TokenFilter, Lexer: LexFilterClause, Optional: true},
+	{Token: TokenWhere, Lexer: LexConditionalClause, Optional: true},
 	{Token: TokenLimit, Lexer: LexNumber, Optional: true},
 	{Token: TokenAlias, Lexer: LexIdentifier, Optional: true},
 	{Token: TokenEOF, Lexer: LexEndOfStatement, Optional: false},
@@ -108,6 +126,6 @@ var FilterStatement = []*Clause{
 //
 var FilterQLDialect *Dialect = &Dialect{
 	Statements: []*Clause{
-		&Clause{Token: TokenFilter, Clauses: FilterStatement},
+		&Clause{Token: TokenNil, Clauses: FilterStatement},
 	},
 }

--- a/lex/dialect_filterql_test.go
+++ b/lex/dialect_filterql_test.go
@@ -85,4 +85,87 @@ func TestFilterQLBasic(t *testing.T) {
 			tv(TokenAlias, "ALIAS"),
 			tv(TokenIdentity, "my_filter_name"),
 		})
+
+	verifyFilterQLTokens(t, `
+    FILTER
+      AND( score > 20 )
+    ALIAS my_filter_name
+    `,
+		[]Token{
+			tv(TokenFilter, "FILTER"),
+			tv(TokenAnd, "AND"),
+			tv(TokenLeftParenthesis, "("),
+			tv(TokenIdentity, "score"),
+			tv(TokenGT, ">"),
+			tv(TokenInteger, "20"),
+			tv(TokenRightParenthesis, ")"),
+			tv(TokenAlias, "ALIAS"),
+			tv(TokenIdentity, "my_filter_name"),
+		})
+
+	verifyFilterQLTokens(t, `
+    FILTER
+      AND(score > 20)
+    ALIAS my_filter_name
+    `,
+		[]Token{
+			tv(TokenFilter, "FILTER"),
+			tv(TokenAnd, "AND"),
+			tv(TokenLeftParenthesis, "("),
+			tv(TokenIdentity, "score"),
+			tv(TokenGT, ">"),
+			tv(TokenInteger, "20"),
+			tv(TokenRightParenthesis, ")"),
+			tv(TokenAlias, "ALIAS"),
+			tv(TokenIdentity, "my_filter_name"),
+		})
+
+	// Ensure we support trailing commas
+	verifyFilterQLTokens(t, `
+    FILTER
+      AND(
+      	score > 20 ,
+      )
+    ALIAS my_filter_name
+    `,
+		[]Token{
+			tv(TokenFilter, "FILTER"),
+			tv(TokenAnd, "AND"),
+			tv(TokenLeftParenthesis, "("),
+			tv(TokenIdentity, "score"),
+			tv(TokenGT, ">"),
+			tv(TokenInteger, "20"),
+			tv(TokenComma, ","),
+			tv(TokenRightParenthesis, ")"),
+			tv(TokenAlias, "ALIAS"),
+			tv(TokenIdentity, "my_filter_name"),
+		})
+
+	// Ensure we support new lines in
+	verifyFilterQLTokens(t, `
+    FILTER
+      AND(
+        score IN (20,
+        30,
+        60)
+      )
+    ALIAS my_filter_name
+    `,
+		[]Token{
+			tv(TokenFilter, "FILTER"),
+			tv(TokenAnd, "AND"),
+			tv(TokenLeftParenthesis, "("),
+			tv(TokenIdentity, "score"),
+			tv(TokenIN, "IN"),
+			tv(TokenLeftParenthesis, "("),
+			tv(TokenInteger, "20"),
+			tv(TokenComma, ","),
+			tv(TokenInteger, "30"),
+			tv(TokenComma, ","),
+			tv(TokenInteger, "60"),
+			tv(TokenRightParenthesis, ")"),
+			tv(TokenRightParenthesis, ")"),
+			tv(TokenAlias, "ALIAS"),
+			tv(TokenIdentity, "my_filter_name"),
+		})
 }

--- a/lex/dialect_json.go
+++ b/lex/dialect_json.go
@@ -1,0 +1,16 @@
+package lex
+
+var jsonDialectStatement = []*Clause{
+	{Token: TokenNil, Lexer: LexJson},
+}
+
+// JsonDialect, is a json lexer
+//
+//    ["hello","world"]
+//    {"name":"bob","apples":["honeycrisp","fuji"]}
+//
+var JsonDialect *Dialect = &Dialect{
+	Statements: []*Clause{
+		&Clause{Token: TokenNil, Clauses: jsonDialectStatement},
+	},
+}

--- a/lex/dialect_json_test.go
+++ b/lex/dialect_json_test.go
@@ -1,0 +1,69 @@
+package lex
+
+import (
+	//u "github.com/araddon/gou"
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+func verifyJsonTokenTypes(t *testing.T, expString string, tokens []TokenType) {
+	l := NewJsonLexer(expString)
+	for _, goodToken := range tokens {
+		tok := l.NextToken()
+		//u.Debugf("%#v  %#v", tok, goodToken)
+		assert.Equalf(t, tok.T, goodToken, "want='%v' has %v ", goodToken, tok)
+	}
+}
+
+func verifyJsonTokens(t *testing.T, expString string, tokens []Token) {
+	l := NewJsonLexer(expString)
+	for i, goodToken := range tokens {
+		tok := l.NextToken()
+		//u.Debugf("%#v  %#v", tok, goodToken)
+		assert.Equalf(t, tok.T, goodToken.T, "%d want token type ='%v' has %v ", i, goodToken.T, tok.T)
+		assert.Equalf(t, tok.V, goodToken.V, "%d want token value='%v' has %v ", i, goodToken.V, tok.V)
+	}
+}
+
+func TestLexJsonTokens(t *testing.T) {
+	verifyJsonTokens(t, `["a",2,"b",true,{"name":"world"}]`,
+		[]Token{
+			tv(TokenLeftBracket, "["),
+			tv(TokenValue, "a"),
+			tv(TokenComma, ","),
+			tv(TokenInteger, "2"),
+			tv(TokenComma, ","),
+			tv(TokenValue, "b"),
+			tv(TokenComma, ","),
+			tv(TokenBool, "true"),
+			tv(TokenComma, ","),
+			tv(TokenLeftBrace, "{"),
+			tv(TokenIdentity, "name"),
+			tv(TokenColon, ":"),
+			tv(TokenValue, "world"),
+			tv(TokenRightBrace, "}"),
+			tv(TokenRightBracket, "]"),
+		})
+}
+
+func TestLexJsonDialect(t *testing.T) {
+	// The lexer should be able to parse json
+	verifyJsonTokenTypes(t, `
+		{
+			"key1":"value2"
+			,"key2":45, 
+			"key3":["a",2,"b",true],
+			"key4":{"hello":"value","age":55}
+		}
+		`,
+		[]TokenType{TokenLeftBrace,
+			TokenIdentity, TokenColon, TokenValue,
+			TokenComma,
+			TokenIdentity, TokenColon, TokenInteger,
+			TokenComma,
+			TokenIdentity, TokenColon, TokenLeftBracket, TokenValue, TokenComma, TokenInteger, TokenComma, TokenValue, TokenComma, TokenBool, TokenRightBracket,
+			TokenComma,
+			TokenIdentity, TokenColon, TokenLeftBrace, TokenIdentity, TokenColon, TokenValue, TokenComma, TokenIdentity, TokenColon, TokenInteger, TokenRightBrace,
+			TokenRightBrace,
+		})
+}

--- a/lex/lexer_test.go
+++ b/lex/lexer_test.go
@@ -24,9 +24,6 @@ func init() {
 func tv(t TokenType, v string) Token {
 	return Token{T: t, V: v}
 }
-func TestDev(t *testing.T) {
-
-}
 
 func token(lexString string, runLex StateFn) Token {
 	l := NewSqlLexer(lexString)
@@ -34,10 +31,23 @@ func token(lexString string, runLex StateFn) Token {
 	return l.NextToken()
 }
 
+func verifyIdentity(t *testing.T, input, expects string, isIdentity bool) {
+	l := NewSqlLexer(input)
+	assert.Tf(t, isIdentity == l.isIdentity(), "Expected %s to be %v identity", input, isIdentity)
+	LexIdentifier(l)
+	tok := l.NextToken()
+	if isIdentity {
+		assert.T(t, tok.T == TokenIdentity)
+		assert.Tf(t, tok.V == expects, "expected %s got %v", expects, tok.V)
+	}
+}
 func TestLexIdentity(t *testing.T) {
-	tok := token("table_name", LexIdentifier)
-	assert.Tf(t, tok.T == TokenIdentity && tok.V == "table_name", "%v", tok.V)
-	tok = token("`table_name`", LexIdentifier)
+	verifyIdentity(t, `"hello"`, "", false)
+	verifyIdentity(t, `[table name]`, "table name", true)
+	verifyIdentity(t, `table_name`, "table_name", true)
+	verifyIdentity(t, "`table_name`", "table_name", true)
+	verifyIdentity(t, "`table name`", "table name", true)
+	tok := token("`table_name`", LexIdentifier)
 	assert.Tf(t, tok.T == TokenIdentity && tok.V == "table_name", "%v", tok)
 	tok = token("`table w *&$% ^ 56 rty`", LexIdentifier)
 	assert.Tf(t, tok.T == TokenIdentity && tok.V == "table w *&$% ^ 56 rty", "%v", tok.V)

--- a/lex/token.go
+++ b/lex/token.go
@@ -181,7 +181,7 @@ const (
 	TokenRegex                TokenType = 193 // regex
 	TokenDuration             TokenType = 194 // 14d , 22w, 3y, 45ms, 45us, 24hr, 2h, 45m, 30s
 
-	// Primitive literal data-types
+	// Scalar literal data-types
 	TokenDataType TokenType = 200 // A generic Identifier of DataTypes
 	TokenBool     TokenType = 201
 	TokenFloat    TokenType = 202
@@ -333,7 +333,7 @@ var (
 		TokenRegex:                {Description: "regex"},
 		TokenDuration:             {Description: "duration"},
 
-		// Primitive literals.
+		// scalar literals.
 		TokenBool:    {Description: "Bool"},
 		TokenFloat:   {Description: "Float"},
 		TokenInteger: {Description: "Integer"},

--- a/value/value.go
+++ b/value/value.go
@@ -409,12 +409,19 @@ func NewSliceValues(v []Value) SliceValue {
 	return SliceValue{v: v, rv: reflect.ValueOf(v)}
 }
 
-func (m SliceValue) Nil() bool                    { return len(m.v) == 0 }
-func (m SliceValue) Err() bool                    { return false }
-func (m SliceValue) Type() ValueType              { return SliceValueType }
-func (m SliceValue) Rv() reflect.Value            { return m.rv }
-func (m SliceValue) Value() interface{}           { return m.v }
-func (m SliceValue) Val() []Value                 { return m.v }
+func (m SliceValue) Nil() bool          { return len(m.v) == 0 }
+func (m SliceValue) Err() bool          { return false }
+func (m SliceValue) Type() ValueType    { return SliceValueType }
+func (m SliceValue) Rv() reflect.Value  { return m.rv }
+func (m SliceValue) Value() interface{} { return m.v }
+func (m SliceValue) Val() []Value       { return m.v }
+func (m SliceValue) ToString() string {
+	sv := make([]string, len(m.Val()))
+	for i, val := range m.v {
+		sv[i] = val.ToString()
+	}
+	return strings.Join(sv, ",")
+}
 func (m *SliceValue) Append(v Value)              { m.v = append(m.v, v) }
 func (m SliceValue) MarshalJSON() ([]byte, error) { return json.Marshal(m.v) }
 func (m SliceValue) Len() int                     { return len(m.v) }


### PR DESCRIPTION
* support native array/json types in Lexer/Parser so that arrays of args can be passed into functions
* refactor filter-ql to support a `SELECT * FROM [table] WHERE [expression]` compiles to same AST as the more concise FilterQL.   
* Fix `join` builtin to support array types