### PR TITLE
Turn parser panics into errors

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -150,7 +150,17 @@ func ParseExpression(expressionText string) (*Tree, error) {
 	pager := NewLexTokenPager(l)
 	t := NewTree(pager)
 	pager.end = lex.TokenEOF
-	err := t.BuildTree(true)
+
+	// Parser panics on unexpected syntax, convert this into an err
+	var err error
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				err = fmt.Errorf("parse error: %v", p)
+			}
+		}()
+		err = t.BuildTree(true)
+	}()
 	return t, err
 }
 

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -171,6 +171,7 @@ var parseTests = []parseTest{
 	{"general parse test", `eq(5,5)`, noError, `eq(5, 5)`},
 	{"general parse test", `oneof("1",item,4)`, noError, `oneof("1", item, 4)`},
 	{"general parse test", `toint("1")`, noError, `toint("1")`},
+	{"invalid in", `"value" IN ident`, hasError, `--skipped due to error--`},
 }
 
 func TestParseExpressions(t *testing.T) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -320,7 +320,7 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) value.Value {
 		panic(ErrUnknownOp)
 	}
 
-	return nil
+	return value.NewErrorValue(fmt.Sprintf("unsupported binary expression: %s", node))
 }
 
 func walkIdentity(ctx expr.EvalContext, node *expr.IdentityNode) (value.Value, bool) {


### PR DESCRIPTION
Also try really hard not to return nil from the vm as that breaks
everything (include value.Value's Nil() method).