### PR TITLE
Fixed nested boolean expressions

### DIFF
--- a/expr/node.go
+++ b/expr/node.go
@@ -65,6 +65,64 @@ const (
 	//SetNodeType         NodeType = 12
 )
 
+// String representation of NodeTypes for diagnostic purposes.
+func (nt NodeType) String() string {
+	switch nt {
+	case NodeNodeType:
+		return "node"
+	case FuncNodeType:
+		return "func"
+	case IdentityNodeType:
+		return "ident"
+	case StringNodeType:
+		return "string"
+	case NumberNodeType:
+		return "number"
+	case ValueNodeType:
+		return "value"
+	case BinaryNodeType:
+		return "binary"
+	case UnaryNodeType:
+		return "unary"
+	case TriNodeType:
+		return "ternary"
+	case MultiArgNodeType:
+		return "multiarg"
+	case NullNodeType:
+		return "null"
+	case SqlPreparedType:
+		return "sql prepared"
+	case SqlSelectNodeType:
+		return "sql select"
+	case SqlInsertNodeType:
+		return "sql insert"
+	case SqlUpdateNodeType:
+		return "sql update"
+	case SqlUpsertNodeType:
+		return "sql upsert"
+	case SqlDeleteNodeType:
+		return "sql delete"
+	case SqlDescribeNodeType:
+		return "sql describe"
+	case SqlShowNodeType:
+		return "sql show"
+	case SqlCommandNodeType:
+		return "sql command"
+	case SqlCreateNodeType:
+		return "sql create"
+	case SqlSourceNodeType:
+		return "sql source"
+	case SqlWhereNodeType:
+		return "sql where"
+	case SqlIntoNodeType:
+		return "sql into"
+	case SqlJoinNodeType:
+		return "sql join"
+	default:
+		return "unknown"
+	}
+}
+
 type (
 
 	// A Node is an element in the expression tree, implemented
@@ -612,7 +670,7 @@ func (m *TriNode) Check() error        { return nil }
 func (m *TriNode) NodeType() NodeType  { return TriNodeType }
 func (m *TriNode) Type() reflect.Value { /* ?? */ return boolRv }
 
-// Urnary nodes
+// Unary nodes
 //    NOT
 //    EXISTS
 func NewUnary(operator lex.Token, arg Node) *UnaryNode {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -282,9 +282,9 @@ Recursion:  We recurse so the LAST to evaluate is the highest (parent, then or)
 
 // expr:
 func (t *Tree) O(depth int) Node {
-	//u.Debugf("depth:%d t.O Cur(): %v", depth, t.Cur())
+	//u.Debugf("depth:%s t.O Cur(): %v", strings.Repeat("→ ", depth), t.Cur())
 	n := t.A(depth)
-	//u.Debugf("depth:%d t.O AFTER: n:%v cur:%v ", depth, n, t.Cur())
+	//u.Debugf("depth:%s t.O AFTER: n:%v cur:%v ", strings.Repeat("→ ", depth), n, t.Cur())
 	for {
 		tok := t.Cur()
 		//u.Debugf("tok:  cur=%v peek=%v", t.Cur(), t.Peek())
@@ -311,9 +311,9 @@ func (t *Tree) O(depth int) Node {
 }
 
 func (t *Tree) A(depth int) Node {
-	//u.Debugf("%d t.A: %v", depth, t.Cur())
+	//u.Debugf("%s t.A: %v", strings.Repeat("→ ", depth), t.Cur())
 	n := t.C(depth)
-	//u.Debugf("%d t.A: AFTER %v", depth, t.Cur())
+	//u.Debugf("%s t.A: AFTER %v", strings.Repeat("→ ", depth), t.Cur())
 	for {
 		//u.Debugf("tok:  cur=%v peek=%v", t.Cur(), t.Peek())
 		switch tok := t.Cur(); tok.T {
@@ -327,14 +327,14 @@ func (t *Tree) A(depth int) Node {
 }
 
 func (t *Tree) C(depth int) Node {
-	//u.Debugf("%d t.C: %v", depth, t.Cur())
+	//u.Debugf("%s t.C: %v", strings.Repeat("→ ", depth), t.Cur())
 	n := t.P(depth)
-	//u.Debugf("%d t.C: %v", depth, t.Cur())
+	//u.Debugf("%s t.C: %v", strings.Repeat("→ ", depth), t.Cur())
 	for {
-		//u.Debugf("tok:  cur=%v peek=%v n=%v", t.Cur(), t.Peek(), n.StringAST())
+		//u.Debugf("tok:  cur=%v peek=%v n=%v", t.Cur(), t.Peek(), n)
 		switch cur := t.Cur(); cur.T {
 		case lex.TokenNegate:
-			//u.Infof("doing urnary node on negate: %v", cur)
+			u.Infof("doing urnary node on negate: %v", cur)
 			t.Next()
 			return NewUnary(cur, t.cInner(n, depth+1))
 		case lex.TokenIs:
@@ -383,9 +383,9 @@ func (t *Tree) cInner(n Node, depth int) Node {
 }
 
 func (t *Tree) P(depth int) Node {
-	//u.Debugf("%d t.P: %v", depth, t.Cur())
+	//u.Debugf("%s t.P: %v", strings.Repeat("→ ", depth), t.Cur())
 	n := t.M(depth)
-	//u.Debugf("%d t.P: AFTER %v", depth, t.Cur())
+	//u.Debugf("%s t.P: AFTER %v", strings.Repeat("→ ", depth), t.Cur())
 	for {
 		switch cur := t.Cur(); cur.T {
 		case lex.TokenPlus, lex.TokenMinus:
@@ -398,9 +398,9 @@ func (t *Tree) P(depth int) Node {
 }
 
 func (t *Tree) M(depth int) Node {
-	//u.Debugf("%d t.M: %v", depth, t.Cur())
+	//u.Debugf("%s t.M: %v", strings.Repeat("→ ", depth), t.Cur())
 	n := t.F(depth)
-	//u.Debugf("%d t.M after: %v  %v", depth, t.Cur(), n)
+	//u.Debugf("%s t.M after: %v  %s", strings.Repeat("→ ", depth), t.Cur(), n.NodeType())
 	for {
 		switch cur := t.Cur(); cur.T {
 		case lex.TokenStar, lex.TokenMultiply, lex.TokenDivide, lex.TokenModulus:
@@ -450,7 +450,7 @@ func (t *Tree) MultiArg(first Node, op lex.Token, depth int) Node {
 }
 
 func (t *Tree) F(depth int) Node {
-	//u.Debugf("%d t.F: %v", depth, t.Cur())
+	//u.Debugf("%s t.F: %v", strings.Repeat("→ ", depth), t.Cur())
 	switch cur := t.Cur(); cur.T {
 	case lex.TokenUdfExpr:
 		return t.v(depth)
@@ -472,12 +472,13 @@ func (t *Tree) F(depth int) Node {
 		// in special situations:   count(*) ??
 		return t.v(depth)
 	case lex.TokenNegate, lex.TokenMinus, lex.TokenExists:
-		//u.Infof("doing urnary node on: %v", cur)
+		//u.Infof("%s doing unary node on: %v", strings.Repeat("→ ", depth), cur)
 		t.Next()
-		return NewUnary(cur, t.F(depth+1))
+		n := NewUnary(cur, t.F(depth+1))
+		//u.Infof("%s returning unary node: %v", strings.Repeat("→ ", depth), cur)
+		return n
 	case lex.TokenIs:
 		nxt := t.Next()
-		//u.Infof("doing urnary node on negate: %v  nxt=%v", cur, nxt)
 		if nxt.T == lex.TokenNegate {
 			return NewUnary(cur, t.F(depth+1))
 		}

--- a/expr/parse_filterql.go
+++ b/expr/parse_filterql.go
@@ -260,7 +260,7 @@ func (m *FilterQLParser) parseFilters() (*Filters, error) {
 
 	for {
 
-		//u.Debug(m.Cur())
+		u.Debug(m.Cur())
 		switch m.Cur().T {
 		case lex.TokenAnd, lex.TokenOr:
 			filters, err := m.parseFilters()

--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -95,7 +95,8 @@ func TestFilterQLAstCheck(t *testing.T) {
 	assert.Equalf(t, len(req.Filter.Filters), 5, "expected 5 filters: %#v", req.Filter)
 	f5 := req.Filter.Filters[4]
 	assert.Tf(t, f5.Expr != nil, "")
-	assert.Tf(t, f5.Expr.String() == "NOT score > 20 ", "%v", f5.Expr)
+	assert.Equal(t, f5.Expr.String(), "NOT (score > 20)")
+	assert.Equalf(t, f5.Expr.NodeType(), UnaryNodeType, "%s != %s", f5.Expr.NodeType(), UnaryNodeType)
 
 	// Make sure we support following features
 	//  - naked single valid expressions that are compound

--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -1,10 +1,11 @@
 package expr
 
 import (
+	"testing"
+
 	u "github.com/araddon/gou"
 	"github.com/araddon/qlbridge/lex"
 	"github.com/bmizerany/assert"
-	"testing"
 )
 
 var (
@@ -84,17 +85,17 @@ func TestFilterQLAstCheck(t *testing.T) {
               momentum > 20
              , propensity > 50
           )
-          , NOT score > 20
+          , NOT ( score > 20 )
        )
     ALIAS my_filter_name
 	`
 	req, err = ParseFilterQL(ql)
 	assert.Tf(t, err == nil && req != nil, "Must parse: %s  \n\t%v", ql, err)
 	assert.Tf(t, req.Alias == "my_filter_name", "has alias: %q", req.Alias)
-	assert.Tf(t, len(req.Filter.Filters) == 4, "has 4 filters: %#v", req.Filter)
-	f4 := req.Filter.Filters[3]
-	assert.Tf(t, f4.Expr != nil, "")
-	assert.Tf(t, f4.Expr.String() == "NOT score > 20", "%v", f4.Expr)
+	assert.Equalf(t, len(req.Filter.Filters), 5, "expected 5 filters: %#v", req.Filter)
+	f5 := req.Filter.Filters[4]
+	assert.Tf(t, f5.Expr != nil, "")
+	assert.Tf(t, f5.Expr.String() == "NOT score > 20 ", "%v", f5.Expr)
 
 	// Make sure we support following features
 	//  - naked single valid expressions that are compound

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -390,17 +390,17 @@ func walkUnary(ctx expr.EvalContext, node *expr.UnaryNode) (value.Value, bool) {
 		if node.Operator.T == lex.TokenExists {
 			return value.NewBoolValue(false), true
 		}
-		u.Debugf("urnary could not evaluate %#v", node)
+		u.Debugf("unary could not evaluate %#v", node)
 		return a, false
 	}
 	switch node.Operator.T {
 	case lex.TokenNegate:
 		switch argVal := a.(type) {
 		case value.BoolValue:
-			//u.Infof("found urnary bool:  res=%v   expr=%v", !argVal.v, node.StringAST())
+			//u.Infof("found unary bool:  res=%v   expr=%v", !argVal.v, node.StringAST())
 			return value.NewBoolValue(!argVal.Val()), true
 		default:
-			//u.Errorf("urnary type not implementedUnknonwn node type:  %T", argVal)
+			u.Errorf("unary type not implemented. Unknonwn node type: %T", argVal)
 			panic(ErrUnknownNodeType)
 		}
 	case lex.TokenMinus:


### PR DESCRIPTION
Nested boolean expressions were being dropped from the AST.

Also test NOT with `()`s as the precedence rules make it apply to the first token after the NOT, so `NOT foo == 5` means `(NOT foo) == 5`

Probably need to fix that someday, but for now we can just enforce the use of ()s with NOTs.

Also started adding easier-to-read indentation to the tree parser.