### PR TITLE
Fix Join Func

### DIFF
--- a/expr/builtins/builtins.go
+++ b/expr/builtins/builtins.go
@@ -506,11 +506,13 @@ func JoinFunc(ctx expr.EvalContext, items ...value.Value) (value.StringValue, bo
 		case value.StringValue, value.NumberValue, value.IntValue:
 			val := valTyped.ToString()
 			if val == "" {
-				return value.EmptyStringValue, false
+				continue
 			}
 			args = append(args, val)
 		}
-
+	}
+	if len(args) == 0 {
+		return value.EmptyStringValue, false
 	}
 	return value.NewStringValue(strings.Join(args, sep)), true
 }

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -104,6 +104,7 @@ var builtinTests = []testBuiltins{
 
 	{`join("apple", event, "oranges", "--")`, value.NewStringValue("apple--hello--oranges")},
 	{`join(["apple","peach"], ",")`, value.NewStringValue("apple,peach")},
+	{`join("apple","","peach",",")`, value.NewStringValue("apple,peach")},
 
 	{`split("apples,oranges",",")`, value.NewStringsValue([]string{"apples", "oranges"})},
 


### PR DESCRIPTION
 - Don't return on empty fields in `JoinFunc`
 - Added tests to reflect change 