### PR TITLE
Return value.ErrorValues from vm.Execute

### DIFF
--- a/value/value.go
+++ b/value/value.go
@@ -736,6 +736,10 @@ func (m ErrorValue) Val() string                       { return m.v }
 func (m ErrorValue) MarshalJSON() ([]byte, error)      { return json.Marshal(m.v) }
 func (m ErrorValue) ToString() string                  { return m.v }
 
+// ErrorValues implement Go's error interface so they can easily cross the
+// VM/Go boundary.
+func (m ErrorValue) Error() string { return m.v }
+
 func NewNilValue() NilValue {
 	return NilValue{}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -99,13 +99,21 @@ func (m *Vm) Execute(writeContext expr.ContextWriter, readContext expr.ContextRe
 	//u.Debugf("vm.Execute:  %#v", m.Tree.Root)
 	v, ok := s.Walk(m.Tree.Root)
 	//u.Infof("v:%v  ok?%v", v, ok)
-	if ok && v != value.ErrValue {
-		// Special Vm that doesnt' have named fields, single tree expression
-		//u.Debugf("vm.Walk val:  %v", v)
-		writeContext.Put(SchemaInfoEmpty, readContext, v)
-		return nil
+
+	// vm unable to walk tree
+	if !ok {
+		return ErrExecute
 	}
-	return ErrExecute
+
+	// vm returned an error value
+	if errv, ok := v.(value.ErrorValue); ok {
+		return errv
+	}
+
+	// Special Vm that doesnt' have named fields, single tree expression
+	//u.Debugf("vm.Walk val:  %v", v)
+	writeContext.Put(SchemaInfoEmpty, readContext, v)
+	return nil
 }
 
 // errRecover is the handler that turns panics into returns from the top

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
-	"github.com/bmizerany/assert"
 )
 
 const (
@@ -81,6 +80,8 @@ var (
 		vmt("binary string ==", `user_id == "abcd"`, false, noError),
 		vmt("binary string ==", `user_id != "abc"`, false, noError),
 		vmtall("binary math err on string +", `user_id > "abc"`, nil, parseOk, evalError),
+		vmt("binary string LIKE", `user_id LIKE "*bc"`, true, noError),
+		vmt("binary string LIKE", `user_id LIKE "\*bc"`, false, noError),
 
 		// Binary Bool
 		vmt("binary bool ==", `bvalt == true`, true, noError),
@@ -176,10 +177,13 @@ func TestRunExpr(t *testing.T) {
 		if err != nil && test.evalok {
 			t.Errorf("\n%s -- %v: \n\t%v\nexpected\n\t'%v'", test.name, test.qlText, results, test.result)
 		}
-		if test.result == nil {
-			assert.Tf(t, results == nil, "%s - should have nil result: %v", test.name, results)
-		} else {
-			assert.Tf(t, results != nil, "%s - should not have nil result: %v", test.name, results)
+		if test.result == nil && results != nil {
+			t.Errorf("%s - should have nil result, but got: %v", test.name, results)
+			continue
+		}
+		if test.result != nil && results == nil {
+			t.Errorf("%s - should have non-nil result but was nil", test.name)
+			continue
 		}
 
 		//u.Infof("results=%T   %#v", results, results)


### PR DESCRIPTION
Kind of blurs the line between Go and the VM, but I think the benefits
to error handling are worth it?