### PR TITLE
Improve ease of implementing DataSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+
+dialects/example/example
+examples/qlcsv/qlcsv

--- a/datasource/csv_test.go
+++ b/datasource/csv_test.go
@@ -1,6 +1,7 @@
 package datasource
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,28 +10,42 @@ import (
 	"github.com/bmizerany/assert"
 )
 
-var testData = map[string]string{
-	"user.csv": `user_id,email,interests,reg_date,item_count
+var (
+	VerboseTests *bool = flag.Bool("vv", false, "Verbose Logging?")
+	_                  = u.EMPTY
+
+	testData = map[string]string{
+		"user.csv": `user_id,email,interests,reg_date,item_count
 9Ip1aKbeZe2njCDM,"aaron@email.com","fishing","2012-10-17T17:29:39.738Z",82
 hT2impsOPUREcVPc,"bob@email.com","swimming","2009-12-11T19:53:31.547Z",12
 hT2impsabc345c,"not_an_email","swimming","2009-12-11T19:53:31.547Z",12`,
-}
+	}
+
+	csvSource       DataSource = &CsvDataSource{}
+	csvStringSource DataSource = &csvStaticSource{testData: testData}
+)
 
 func init() {
-	// Register our Datasources in registry
-	Register("csv", &CsvDataSource{})
-	Register("csvtest", &csvStringSource{testData: testData})
+	flag.Parse()
+	if *VerboseTests {
+		u.SetupLogging("debug")
+	} else {
+		u.SetupLogging("info")
+	}
 
-	u.SetupLogging("debug")
 	u.SetColorOutput()
+
+	// Register our Datasources in registry
+	Register("csv", csvSource)
+	Register("csvtest", csvStringSource)
 }
 
-type csvStringSource struct {
+type csvStaticSource struct {
 	*CsvDataSource
 	testData map[string]string
 }
 
-func (m *csvStringSource) Open(connInfo string) (SourceConn, error) {
+func (m *csvStaticSource) Open(connInfo string) (SourceConn, error) {
 	if data, ok := m.testData[connInfo]; ok {
 		sr := strings.NewReader(data)
 		return NewCsvSource(connInfo, 0, sr, make(<-chan bool, 1))
@@ -41,7 +56,8 @@ func (m *csvStringSource) Open(connInfo string) (SourceConn, error) {
 func TestCsvDatasource(t *testing.T) {
 	// register some test data
 	// Create a csv data source from stdin
-	csvIn, err := OpenConn("csvtest", "user.csv")
+	//csvIn, err := OpenConn("csvtest", "user.csv")
+	csvIn, err := csvStringSource.Open("user.csv")
 	assert.Tf(t, err == nil, "should not have error: %v", err)
 	csvIter, ok := csvIn.(Scanner)
 	assert.T(t, ok)

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -93,13 +93,6 @@ type SourceSelectPlanner interface {
 }
 */
 
-// Some sources can do their own planning for sub-select statements
-type SourceSelectPlanner interface {
-	// return a source plan builder, which implements Accept() visitor interface
-	SubSelectVisitor() (expr.SubVisitor, error)
-	Projection
-}
-
 // A scanner, most basic of data sources, just iterate through
 //  rows without any optimizations
 type Scanner interface {
@@ -148,12 +141,14 @@ type Aggregations interface {
 	Aggregate(expr.SqlStatement) error
 }
 
+/*
 // Some data sources that implement more features, can provide
 //  their own projection.
 type Projection interface {
 	// Describe the Columns etc
 	Projection() (*expr.Projection, error)
 }
+*/
 
 // SourceMutation, is a statefull connection similar to Open() connection for select
 //  - accepts the stmt used in this upsert/insert/update
@@ -191,19 +186,18 @@ type Deletion interface {
 // We do type introspection in advance to speed up runtime
 // feature detection for datasources
 type Features struct {
+	//Projection          bool
 	//SourceSelectPlanner bool
-	SourceSelectPlanner bool
-	Scanner             bool
-	Seeker              bool
-	WhereFilter         bool
-	GroupBy             bool
-	Sort                bool
-	Aggregations        bool
-	Projection          bool
-	SourceMutation      bool
-	Upsert              bool
-	PatchWhere          bool
-	Deletion            bool
+	Scanner        bool
+	Seeker         bool
+	WhereFilter    bool
+	GroupBy        bool
+	Sort           bool
+	Aggregations   bool
+	SourceMutation bool
+	Upsert         bool
+	PatchWhere     bool
+	Deletion       bool
 }
 type DataSourceFeatures struct {
 	Features *Features
@@ -216,9 +210,9 @@ func NewFeaturedSource(src DataSource) *DataSourceFeatures {
 func NewFeatures(src DataSource) *Features {
 	f := Features{}
 	//u.Infof("analyze: %#v", src)
-	if _, ok := src.(SourceSelectPlanner); ok {
-		f.SourceSelectPlanner = true
-	}
+	// if _, ok := src.(SourceSelectPlanner); ok {
+	// 	f.SourceSelectPlanner = true
+	// }
 	if _, ok := src.(Scanner); ok {
 		f.Scanner = true
 	}
@@ -237,9 +231,9 @@ func NewFeatures(src DataSource) *Features {
 	if _, ok := src.(Aggregations); ok {
 		f.Aggregations = true
 	}
-	if _, ok := src.(Projection); ok {
-		f.Projection = true
-	}
+	// if _, ok := src.(Projection); ok {
+	// 	f.Projection = true
+	// }
 	if _, ok := src.(SourceMutation); ok {
 		f.SourceMutation = true
 	}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -87,7 +87,7 @@ type SourceConn interface {
 type SourceSelectPlanner interface {
 	// Accept a sql statement, to plan the execution ideally, this would be done
 	// by planner but, we need source specific planners, as each backend has different features
-	//Accept(expr.Visitor) (Scanner, error)
+	// Accept(expr.Visitor) (Scanner, error)
 	VisitSelect(stmt *expr.SqlSelect) (interface{}, error)
 }
 
@@ -95,7 +95,7 @@ type SourceSelectPlanner interface {
 type SourcePlanner interface {
 	// Accept a sql statement, to plan the execution ideally, this would be done
 	// by planner but, we need source specific planners, as each backend has different features
-	Accept(expr.SubVisitor) (Scanner, error)
+	Builder() (expr.SubVisitor, error)
 }
 
 // A scanner, most basic of data sources, just iterate through

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -65,6 +65,12 @@ type SchemaColumns interface {
 	Columns() []string
 }
 
+// Interface for a data source exposing column positions for []driver.Value iteration
+type SchemaSource interface {
+	DataSource
+	Columns() []string
+}
+
 // A backend data source provider that also provides schema
 type SchemaProvider interface {
 	DataSource
@@ -91,6 +97,7 @@ type SourceSelectPlanner interface {
 type SourceSelectPlanner interface {
 	// return a source plan builder, which implements Accept() visitor interface
 	SubSelectVisitor() (expr.SubVisitor, error)
+	Projection
 }
 
 // A scanner, most basic of data sources, just iterate through

--- a/datasource/membtree/btree.go
+++ b/datasource/membtree/btree.go
@@ -28,8 +28,9 @@ var (
 	_ datasource.SchemaColumns = (*StaticDataSource)(nil)
 	_ datasource.Scanner       = (*StaticDataSource)(nil)
 	_ datasource.Seeker        = (*StaticDataSource)(nil)
-	_ datasource.Upsert        = (*StaticDataSource)(nil)
-	_ datasource.Deletion      = (*StaticDataSource)(nil)
+	//_ datasource.SourceMutation = (*StaticDataSource)(nil)
+	_ datasource.Upsert   = (*StaticDataSource)(nil)
+	_ datasource.Deletion = (*StaticDataSource)(nil)
 )
 
 type Key struct {
@@ -107,6 +108,7 @@ func makeId(dv driver.Value) uint64 {
 // Features
 // - only a single column may (and must) be identified as the "Indexed" column
 // - NOT threadsafe
+// - each StaticDataSource = a single Table
 //
 // This is meant as an example of the interfaces of qlbridge DataSources
 //
@@ -153,7 +155,8 @@ func NewStaticData(name string) *StaticDataSource {
 	return NewStaticDataSource(name, 0, make([][]driver.Value, 0), nil)
 }
 
-func (m *StaticDataSource) Open(connInfo string) (datasource.SourceConn, error) { return nil, nil }
+func (m *StaticDataSource) Open(connInfo string) (datasource.SourceConn, error) { return m, nil }
+func (m *StaticDataSource) Table(table string) (*datasource.Table, error)       { return nil, nil }
 func (m *StaticDataSource) Close() error                                        { return nil }
 func (m *StaticDataSource) CreateIterator(filter expr.Node) datasource.Iterator { return m }
 func (m *StaticDataSource) Tables() []string                                    { return []string{m.Schema.Name} }

--- a/datasource/mockcsv/mockcsv.go
+++ b/datasource/mockcsv/mockcsv.go
@@ -13,9 +13,8 @@ import (
 var (
 	_ = u.EMPTY
 
-	// Different Features of this MockCsv Data Source
-	// - the rest are implemented in the static data source
-	//   which has a Static per table
+	// Enforce Features of this MockCsv Data Source
+	// - the rest are implemented in the static data source which has a Static per table
 	_ datasource.DataSource = (*MockCsvSource)(nil)
 
 	MockCsvGlobal = NewMockSource()

--- a/datasource/schemaregistry.go
+++ b/datasource/schemaregistry.go
@@ -205,7 +205,7 @@ func (m *DataSources) Get(sourceName string) *DataSourceFeatures {
 		u.LogTracef(u.WARN, "No Source Name?")
 		return nil
 	}
-	u.Debugf("datasource.Get('%v')", sourceName)
+	//u.Debugf("datasource.Get('%v')", sourceName)
 
 	if len(m.tableSources) == 0 {
 		for _, src := range m.sources {
@@ -214,7 +214,7 @@ func (m *DataSources) Get(sourceName string) *DataSourceFeatures {
 				if _, ok := m.tableSources[tbl]; ok {
 					u.Warnf("table names must be unique across sources %v", tbl)
 				} else {
-					u.Debugf("creating tbl/source: %v  %T", tbl, src)
+					//u.Debugf("creating tbl/source: %v  %T", tbl, src)
 					m.tableSources[tbl] = src
 				}
 			}

--- a/datasource/schemaregistry.go
+++ b/datasource/schemaregistry.go
@@ -256,7 +256,7 @@ func Register(sourceName string, source DataSource) {
 		panic("qlbridge/datasource: Register driver is nil")
 	}
 	sourceName = strings.ToLower(sourceName)
-	u.Warnf("global source register datasource: %v %T", sourceName, source)
+	u.Debugf("global source register datasource: %v %T", sourceName, source)
 	//u.LogTracef(u.WARN, "adding source %T to registry", source)
 	sourceMu.Lock()
 	defer sourceMu.Unlock()

--- a/exec/build.go
+++ b/exec/build.go
@@ -1,8 +1,6 @@
 package exec
 
 import (
-	"fmt"
-
 	u "github.com/araddon/gou"
 
 	"github.com/araddon/qlbridge/datasource"
@@ -40,117 +38,12 @@ func NewJobBuilder(conf *datasource.RuntimeSchema, connInfo string) *JobBuilder 
 	return &b
 }
 
-func (m *JobBuilder) VisitPreparedStmt(stmt *expr.PreparedStatement) (expr.Task, error) {
+func (m *JobBuilder) VisitPreparedStmt(stmt *expr.PreparedStatement) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitPreparedStmt %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitFinal, expr.ErrNotImplemented
 }
 
-func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
-
-	u.Debugf("VisitInsert %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	insertTask := NewInsertUpsert(stmt, source)
-	//u.Infof("adding insert: %#v", insertTask)
-	tasks.Add(insertTask)
-
-	return NewSequential("insert", tasks), nil
-}
-
-func (m *JobBuilder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
-	u.Debugf("VisitUpdate %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	updateTask := NewUpdateUpsert(stmt, source)
-	//u.Infof("adding update: %#v", updateTask)
-	tasks.Add(updateTask)
-
-	return NewSequential("update", tasks), nil
-}
-
-func (m *JobBuilder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
-
-	u.Debugf("VisitUpsert %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	upsertTask := NewUpsertUpsert(stmt, source)
-	//u.Infof("adding upsert: %#v", upsertTask)
-	tasks.Add(upsertTask)
-
-	return NewSequential("upsert", tasks), nil
-}
-
-func (m *JobBuilder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
-	u.Debugf("VisitDelete %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %q", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Deletion)
-	if !ok {
-		// If this datasource doesn't implement delete, do a scan + delete?
-		return nil, fmt.Errorf("%T Must Implement Delete", dataSource)
-	}
-
-	deleteTask := NewDelete(stmt, source)
-	//u.Infof("adding delete task: %#v", deleteTask)
-	tasks.Add(deleteTask)
-
-	return NewSequential("delete", tasks), nil
-}
-
-func (m *JobBuilder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
-	u.Debugf("VisitShow %+v", stmt)
-	return nil, expr.ErrNotImplemented
-}
-
-func (m *JobBuilder) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, error) {
-	u.Debugf("VisitDescribe %+v", stmt)
-	return nil, expr.ErrNotImplemented
-}
-
-func (m *JobBuilder) VisitCommand(stmt *expr.SqlCommand) (expr.Task, error) {
+func (m *JobBuilder) VisitCommand(stmt *expr.SqlCommand) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitCommand %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitFinal, expr.ErrNotImplemented
 }

--- a/exec/build.go
+++ b/exec/build.go
@@ -21,11 +21,12 @@ var (
 //   we can create smarter ones but this is a basic implementation for
 ///  running in-process, not distributed
 type JobBuilder struct {
-	Conf     *datasource.RuntimeSchema
-	connInfo string
-	where    expr.Node
-	distinct bool
-	children Tasks
+	Conf       *datasource.RuntimeSchema
+	Projection *expr.Projection
+	connInfo   string
+	where      expr.Node
+	distinct   bool
+	children   Tasks
 }
 
 // JobBuilder

--- a/exec/build.go
+++ b/exec/build.go
@@ -21,7 +21,7 @@ var (
 //   we can create smarter ones but this is a basic implementation for
 ///  running in-process, not distributed
 type JobBuilder struct {
-	schema   *datasource.RuntimeSchema
+	Conf     *datasource.RuntimeSchema
 	connInfo string
 	where    expr.Node
 	distinct bool
@@ -29,12 +29,12 @@ type JobBuilder struct {
 }
 
 // JobBuilder
-//   @schema   = the config/runtime schema info
+//   @conf   = the config/runtime schema info
 //   @connInfo = connection string info for original connection
 //
-func NewJobBuilder(schema *datasource.RuntimeSchema, connInfo string) *JobBuilder {
+func NewJobBuilder(conf *datasource.RuntimeSchema, connInfo string) *JobBuilder {
 	b := JobBuilder{}
-	b.schema = schema
+	b.Conf = conf
 	b.connInfo = connInfo
 	return &b
 }
@@ -50,7 +50,7 @@ func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
 	tasks := make(Tasks, 0)
 
 	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.schema.Conn(stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
 	if dataSource == nil {
 		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
 	}
@@ -73,7 +73,7 @@ func (m *JobBuilder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
 	tasks := make(Tasks, 0)
 
 	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.schema.Conn(stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
 	if dataSource == nil {
 		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
 	}
@@ -97,7 +97,7 @@ func (m *JobBuilder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
 	tasks := make(Tasks, 0)
 
 	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.schema.Conn(stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
 	if dataSource == nil {
 		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
 	}
@@ -120,7 +120,7 @@ func (m *JobBuilder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
 	tasks := make(Tasks, 0)
 
 	//u.Infof("get SourceConn: %q", stmt.Table)
-	dataSource := m.schema.Conn(stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
 	if dataSource == nil {
 		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
 	}

--- a/exec/build.go
+++ b/exec/build.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/plan"
 )
 
 var (
 	_ = u.EMPTY
 
 	// Ensure that we implement the sql expr.Visitor interface
-	_ expr.Visitor    = (*JobBuilder)(nil)
-	_ expr.SubVisitor = (*JobBuilder)(nil)
+	_ expr.Visitor       = (*JobBuilder)(nil)
+	_ plan.SourceVisitor = (*JobBuilder)(nil)
 )
 
 // This is a simple, single source Job Executor
@@ -20,7 +21,7 @@ var (
 ///  running in-process, not distributed
 type JobBuilder struct {
 	Conf       *datasource.RuntimeSchema
-	Projection *expr.Projection
+	Projection *plan.Projection
 	connInfo   string
 	where      expr.Node
 	distinct   bool

--- a/exec/build_mutate.go
+++ b/exec/build_mutate.go
@@ -13,102 +13,6 @@ var (
 	_ = u.EMPTY
 )
 
-/*
-func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
-
-	u.Debugf("VisitInsert %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	insertTask := NewInsertUpsert(stmt, source)
-	//u.Infof("adding insert: %#v", insertTask)
-	tasks.Add(insertTask)
-
-	return NewSequential("insert", tasks), nil
-}
-func (m *JobBuilder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
-	u.Debugf("VisitUpdate %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	updateTask := NewUpdateUpsert(stmt, source)
-	//u.Infof("adding update: %#v", updateTask)
-	tasks.Add(updateTask)
-
-	return NewSequential("update", tasks), nil
-}
-
-func (m *JobBuilder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
-
-	u.Debugf("VisitUpsert %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %v", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Upsert)
-	if !ok {
-		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
-	}
-
-	upsertTask := NewUpsertUpsert(stmt, source)
-	//u.Infof("adding upsert: %#v", upsertTask)
-	tasks.Add(upsertTask)
-
-	return NewSequential("upsert", tasks), nil
-}
-
-func (m *JobBuilder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
-	u.Debugf("VisitDelete %+v", stmt)
-	tasks := make(Tasks, 0)
-
-	//u.Infof("get SourceConn: %q", stmt.Table)
-	dataSource := m.Conf.Conn(stmt.Table)
-	if dataSource == nil {
-		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
-	}
-	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
-	// Must provider either Scanner, and or Seeker interfaces
-	source, ok := dataSource.(datasource.Deletion)
-	if !ok {
-		// If this datasource doesn't implement delete, do a scan + delete?
-		return nil, fmt.Errorf("%T Must Implement Delete", dataSource)
-	}
-
-	deleteTask := NewDelete(stmt, source)
-	//u.Infof("adding delete task: %#v", deleteTask)
-	tasks.Add(deleteTask)
-
-	return NewSequential("delete", tasks), nil
-}
-
-*/
 func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, expr.VisitStatus, error) {
 
 	u.Debugf("VisitInsert %s", stmt)
@@ -129,7 +33,7 @@ func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, expr.VisitSta
 		//upsertDs := ds.DataSource.(datasource.Upsert)
 		insertTask := NewInsertUpsert(stmt, upsertDs)
 		u.Debugf("adding insert source %#v", upsertDs)
-		u.Infof("adding insert: %#v", insertTask)
+		u.Debugf("adding insert: %#v", insertTask)
 		tasks.Add(insertTask)
 	} else {
 		u.Warnf("doesn't implement upsert? %T", source)

--- a/exec/build_mutate.go
+++ b/exec/build_mutate.go
@@ -1,0 +1,259 @@
+package exec
+
+import (
+	"fmt"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/datasource"
+	"github.com/araddon/qlbridge/expr"
+)
+
+var (
+	_ = u.EMPTY
+)
+
+/*
+func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
+
+	u.Debugf("VisitInsert %+v", stmt)
+	tasks := make(Tasks, 0)
+
+	//u.Infof("get SourceConn: %v", stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
+	if dataSource == nil {
+		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
+	}
+	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
+	// Must provider either Scanner, and or Seeker interfaces
+	source, ok := dataSource.(datasource.Upsert)
+	if !ok {
+		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
+	}
+
+	insertTask := NewInsertUpsert(stmt, source)
+	//u.Infof("adding insert: %#v", insertTask)
+	tasks.Add(insertTask)
+
+	return NewSequential("insert", tasks), nil
+}
+func (m *JobBuilder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
+	u.Debugf("VisitUpdate %+v", stmt)
+	tasks := make(Tasks, 0)
+
+	//u.Infof("get SourceConn: %v", stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
+	if dataSource == nil {
+		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
+	}
+	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
+	// Must provider either Scanner, and or Seeker interfaces
+	source, ok := dataSource.(datasource.Upsert)
+	if !ok {
+		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
+	}
+
+	updateTask := NewUpdateUpsert(stmt, source)
+	//u.Infof("adding update: %#v", updateTask)
+	tasks.Add(updateTask)
+
+	return NewSequential("update", tasks), nil
+}
+
+func (m *JobBuilder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
+
+	u.Debugf("VisitUpsert %+v", stmt)
+	tasks := make(Tasks, 0)
+
+	//u.Infof("get SourceConn: %v", stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
+	if dataSource == nil {
+		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
+	}
+	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
+	// Must provider either Scanner, and or Seeker interfaces
+	source, ok := dataSource.(datasource.Upsert)
+	if !ok {
+		return nil, fmt.Errorf("%T Must Implement Upsert", dataSource)
+	}
+
+	upsertTask := NewUpsertUpsert(stmt, source)
+	//u.Infof("adding upsert: %#v", upsertTask)
+	tasks.Add(upsertTask)
+
+	return NewSequential("upsert", tasks), nil
+}
+
+func (m *JobBuilder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
+	u.Debugf("VisitDelete %+v", stmt)
+	tasks := make(Tasks, 0)
+
+	//u.Infof("get SourceConn: %q", stmt.Table)
+	dataSource := m.Conf.Conn(stmt.Table)
+	if dataSource == nil {
+		return nil, fmt.Errorf("No table '%s' found", stmt.Table)
+	}
+	//u.Debugf("sourceConn: %T  %#v", dataSource, dataSource)
+	// Must provider either Scanner, and or Seeker interfaces
+	source, ok := dataSource.(datasource.Deletion)
+	if !ok {
+		// If this datasource doesn't implement delete, do a scan + delete?
+		return nil, fmt.Errorf("%T Must Implement Delete", dataSource)
+	}
+
+	deleteTask := NewDelete(stmt, source)
+	//u.Infof("adding delete task: %#v", deleteTask)
+	tasks.Add(deleteTask)
+
+	return NewSequential("delete", tasks), nil
+}
+
+*/
+func (m *JobBuilder) VisitInsert(stmt *expr.SqlInsert) (expr.Task, expr.VisitStatus, error) {
+
+	u.Debugf("VisitInsert %s", stmt)
+	//u.Debugf("VisitInsert %T  %s\n%#v", stmt, stmt.String(), stmt)
+	tasks := make(Tasks, 0)
+
+	ds := m.Conf.Sources.Get(stmt.Table)
+	if ds == nil {
+		u.Warnf("error finding table %v", stmt.Table)
+		return nil, expr.VisitError, datasource.ErrNotFound
+	}
+	source, err := ds.DataSource.Open(stmt.Table)
+	if err != nil {
+		return nil, expr.VisitError, err
+	}
+
+	if upsertDs, isUpsert := source.(datasource.Upsert); isUpsert {
+		//upsertDs := ds.DataSource.(datasource.Upsert)
+		insertTask := NewInsertUpsert(stmt, upsertDs)
+		u.Debugf("adding insert source %#v", upsertDs)
+		u.Infof("adding insert: %#v", insertTask)
+		tasks.Add(insertTask)
+	} else {
+		u.Warnf("doesn't implement upsert? %T", source)
+		return nil, expr.VisitError, fmt.Errorf("%T Must Implement Upsert or SourceMutation", source)
+	}
+
+	return NewSequential("insert", tasks), expr.VisitContinue, nil
+}
+
+func (m *JobBuilder) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, expr.VisitStatus, error) {
+	u.Debugf("VisitUpdate %+v", stmt)
+	//u.Debugf("VisitUpdate %T  %s\n%#v", stmt, stmt.String(), stmt)
+	tasks := make(Tasks, 0)
+
+	ds := m.Conf.Sources.Get(stmt.Table)
+	if ds == nil {
+		u.Warnf("error finding table %v", stmt.Table)
+		return nil, expr.VisitError, datasource.ErrNotFound
+	}
+	source, err := ds.DataSource.Open(stmt.Table)
+	if err != nil {
+		return nil, expr.VisitError, err
+	}
+
+	mutatorSource, hasMutator := source.(datasource.SourceMutation)
+	if hasMutator {
+		mutator, err := mutatorSource.CreateMutator(stmt)
+		if err != nil {
+			u.Errorf("could not create mutator %v", err)
+		} else {
+			task := NewUpdateUpsert(stmt, mutator)
+			//u.Debugf("adding delete source %#v", source)
+			//u.Infof("adding delete: %#v", task)
+			tasks.Add(task)
+			return NewSequential("update", tasks), expr.VisitContinue, nil
+		}
+	}
+	updateSource, hasUpdate := source.(datasource.Upsert)
+	if !hasUpdate {
+		return nil, expr.VisitError, fmt.Errorf("%T Must Implement Update or SourceMutation", ds.DataSource)
+	}
+	task := NewUpdateUpsert(stmt, updateSource)
+	tasks.Add(task)
+	//u.Debugf("adding update source %#v", source)
+	return NewSequential("update", tasks), expr.VisitContinue, nil
+}
+
+func (m *JobBuilder) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, expr.VisitStatus, error) {
+	u.Debugf("VisitUpsert %+v", stmt)
+	//u.Debugf("VisitUpsert %T  %s\n%#v", stmt, stmt.String(), stmt)
+	tasks := make(Tasks, 0)
+
+	ds := m.Conf.Sources.Get(stmt.Table)
+	if ds == nil {
+		u.Warnf("error finding table %v", stmt.Table)
+		return nil, expr.VisitError, datasource.ErrNotFound
+	}
+	source, err := ds.DataSource.Open(stmt.Table)
+	if err != nil {
+		return nil, expr.VisitError, err
+	}
+
+	mutatorSource, hasMutator := source.(datasource.SourceMutation)
+	if hasMutator {
+		mutator, err := mutatorSource.CreateMutator(stmt)
+		if err != nil {
+			u.Errorf("could not create mutator %v", err)
+		} else {
+			task := NewUpsertUpsert(stmt, mutator)
+			//u.Debugf("adding delete source %#v", source)
+			//u.Infof("adding delete: %#v", task)
+			tasks.Add(task)
+			return NewSequential("update", tasks), expr.VisitContinue, nil
+		}
+	}
+	updateSource, hasUpdate := source.(datasource.Upsert)
+	if !hasUpdate {
+		return nil, expr.VisitError, fmt.Errorf("%T Must Implement Update or SourceMutation", ds.DataSource)
+	}
+	task := NewUpsertUpsert(stmt, updateSource)
+	tasks.Add(task)
+	//u.Debugf("adding update source %#v", source)
+	return NewSequential("update", tasks), expr.VisitContinue, nil
+}
+
+func (m *JobBuilder) VisitDelete(stmt *expr.SqlDelete) (expr.Task, expr.VisitStatus, error) {
+	u.Debugf("VisitDelete %+v", stmt)
+	tasks := make(Tasks, 0)
+
+	// ds := m.Conf.Sources.Get(stmt.Table)
+	// if ds == nil {
+	// 	u.Warnf("error finding table %v", stmt.Table)
+	// 	return nil, datasource.ErrNotFound
+	// }
+
+	ds := m.Conf.Sources.Get(stmt.Table)
+	if ds == nil {
+		return nil, expr.VisitError, fmt.Errorf("Could not find source for %v", stmt.Table)
+	}
+	source, err := ds.DataSource.Open(stmt.Table)
+	if err != nil {
+		return nil, expr.VisitError, err
+	}
+
+	mutatorSource, hasMutator := source.(datasource.SourceMutation)
+	if hasMutator {
+		mutator, err := mutatorSource.CreateMutator(stmt)
+		if err != nil {
+			u.Errorf("could not create mutator %v", err)
+		} else {
+			task := NewDelete(stmt, mutator)
+			//u.Debugf("adding delete source %#v", source)
+			//u.Infof("adding delete: %#v", task)
+			tasks.Add(task)
+			return NewSequential("delete", tasks), expr.VisitContinue, nil
+		}
+	}
+	deletionSource, hasDeletion := source.(datasource.Deletion)
+	if !hasDeletion {
+		return nil, expr.VisitError, fmt.Errorf("%T Must Implement Deletion or SourceMutation", ds.DataSource)
+	}
+	task := NewDelete(stmt, deletionSource)
+	//u.Debugf("adding delete source %#v", source)
+	//u.Infof("adding delete: %#v", task)
+	tasks.Add(task)
+	return NewSequential("delete", tasks), expr.VisitContinue, nil
+}

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -235,9 +235,11 @@ func (m *JobBuilder) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.Vis
 	}
 
 	// Add a Non-Final Projection to choose the columns for results
-	// projection := NewProjectionInProcess(from.Source)
-	// u.Debugf("source projection: %p added  %s", projection, from.Source.String())
-	// tasks.Add(projection)
+	if !sp.Final {
+		projection := NewProjectionInProcess(from.Source)
+		u.Debugf("source projection: %p added  %s", projection, from.Source.String())
+		tasks.Add(projection)
+	}
 
 	if needsJoinKey {
 		joinKeyTask, err := NewJoinKey(from, m.Conf)

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -234,6 +234,11 @@ func (m *JobBuilder) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.Vis
 		}
 	}
 
+	// Add a Non-Final Projection to choose the columns for results
+	// projection := NewProjectionInProcess(from.Source)
+	// u.Debugf("source projection: %p added  %s", projection, from.Source.String())
+	// tasks.Add(projection)
+
 	if needsJoinKey {
 		joinKeyTask, err := NewJoinKey(from, m.Conf)
 		if err != nil {

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -123,6 +123,7 @@ func (m *JobBuilder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitSta
 // positional []driver.Value args, mutate the *from* itself to hold this map
 func buildColIndex(sourceConn datasource.SourceConn, sp *plan.SourcePlan) error {
 	if sp.Source == nil {
+		u.Errorf("Couldnot build colindex bc no source %#v", sp)
 		return nil
 	}
 	colSchema, ok := sourceConn.(datasource.SchemaColumns)
@@ -146,14 +147,6 @@ func (m *JobBuilder) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.Vis
 	needsJoinKey := false
 	from := sp.SqlSource
 
-	// sourceFeatures := m.Conf.Sources.Get(sp.SourceName())
-	// if sourceFeatures == nil {
-	// 	return nil, expr.VisitError, fmt.Errorf("Could not find source for %v", sp.SourceName())
-	// }
-	// source, err := sourceFeatures.DataSource.Open(sp.SourceName())
-	// if err != nil {
-	// 	return nil, expr.VisitError, err
-	// }
 	source, err := sp.DataSource.DataSource.Open(sp.SourceName())
 	if err != nil {
 		return nil, expr.VisitError, err

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -37,7 +37,7 @@ func (m *JobBuilder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitSta
 			return nil, status, err
 		}
 		if status == expr.VisitFinal {
-			u.Warnf("subselect visit final returning job.proj: %p", m.Projection)
+			u.Debugf("subselect visit final returning job.proj: %p", m.Projection)
 			return task, status, nil
 		}
 		tasks.Add(task.(TaskRunner))
@@ -104,7 +104,7 @@ func (m *JobBuilder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitSta
 	// Add a Final Projection to choose the columns for results
 	projection := NewProjectionFinal(stmt)
 	m.Projection = nil
-	u.Infof("%p projection added  %s", projection, stmt.String())
+	u.Infof("exec.projection: %p added  %s", projection, stmt.String())
 	tasks.Add(projection)
 
 	return NewSequential("select", tasks), expr.VisitContinue, nil

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -103,7 +103,8 @@ func (m *JobBuilder) VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitSta
 
 	// Add a Final Projection to choose the columns for results
 	projection := NewProjection(stmt)
-	//u.Infof("adding projection: %#v", projection)
+	m.Projection = nil
+	u.Infof("%p projection added  %s", projection, stmt.String())
 	tasks.Add(projection)
 
 	return NewSequential("select", tasks), expr.VisitContinue, nil
@@ -172,6 +173,7 @@ func (m *JobBuilder) VisitSubSelect(from *expr.SqlSource) (expr.Task, expr.Visit
 			return nil, status, err
 		}
 		if status == expr.VisitFinal {
+
 			m.Projection, _ = sourcePlan.Projection()
 			tasks.Add(task.(TaskRunner))
 

--- a/exec/build_select.go
+++ b/exec/build_select.go
@@ -189,7 +189,7 @@ func (m *JobBuilder) VisitSourceSelect(sp *plan.SourcePlan) (expr.Task, expr.Vis
 			//return task, status, nil
 		}
 		if task != nil {
-			u.Infof("found task?")
+			//u.Infof("found task?")
 			//tasks.Add(task)
 			//return NewSequential("source-planner", tasks), nil
 			return task, expr.VisitContinue, nil

--- a/exec/build_show.go
+++ b/exec/build_show.go
@@ -1,0 +1,216 @@
+package exec
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/datasource"
+	"github.com/araddon/qlbridge/datasource/membtree"
+	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/value"
+)
+
+var (
+	_ = u.EMPTY
+)
+
+/*
+func (m *JobBuilder) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
+	u.Debugf("VisitShow %+v", stmt)
+	return nil, expr.ErrNotImplemented
+}
+
+func (m *JobBuilder) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, error) {
+	u.Debugf("VisitDescribe %+v", stmt)
+	return nil, expr.ErrNotImplemented
+}
+*/
+
+func DescribeTable(tbl *datasource.Table) (*membtree.StaticDataSource, *expr.Projection) {
+	if len(tbl.Fields) == 0 {
+		u.Warnf("NO Fields!!!!! for %s p=%p", tbl.Name, tbl)
+	}
+	proj := expr.NewProjection()
+	for _, f := range datasource.DescribeHeaders {
+		proj.AddColumnShort(string(f.Name), f.Type)
+		//u.Debugf("found field:  vals=%#v", f)
+	}
+	tableVals := membtree.NewStaticDataSource("describetable", 0, tbl.DescribeValues, datasource.DescribeCols)
+	return tableVals, proj
+}
+
+func ShowTables(s *datasource.RuntimeSchema) (*membtree.StaticDataSource, *expr.Projection) {
+
+	tables := s.Tables()
+	vals := make([][]driver.Value, len(tables))
+	idx := 0
+	if len(tables) == 0 {
+		u.Warnf("NO TABLES!!!!! for %+v", s)
+	}
+	for _, tbl := range tables {
+		vals[idx] = []driver.Value{tbl}
+		//u.Infof("found table: %v   vals=%v", tbl, vals[idx])
+		idx++
+	}
+	showTableVals := membtree.NewStaticDataSource("schematables", 0, vals, []string{"Table"})
+	proj := expr.NewProjection()
+	proj.AddColumnShort("Table", value.StringType)
+	//u.Infof("showtables:  %v", m.showTableVals)
+	return showTableVals, proj
+}
+
+func ShowVariables(name string, val driver.Value) (*membtree.StaticDataSource, *expr.Projection) {
+	/*
+	   MariaDB [(none)]> SHOW SESSION VARIABLES LIKE 'lower_case_table_names';
+	   +------------------------+-------+
+	   | Variable_name          | Value |
+	   +------------------------+-------+
+	   | lower_case_table_names | 0     |
+	   +------------------------+-------+
+	*/
+	vals := make([][]driver.Value, 1)
+	vals[0] = []driver.Value{name, val}
+	dataSource := membtree.NewStaticDataSource("schematables", 0, vals, []string{"Variable_name", "Value"})
+	p := expr.NewProjection()
+	p.AddColumnShort("Variable_name", value.StringType)
+	p.AddColumnShort("Value", value.StringType)
+	return dataSource, p
+}
+
+func (m *JobBuilder) emptyTask(name string) (TaskRunner, expr.VisitStatus, error) {
+	source := membtree.NewStaticDataSource(name, 0, nil, []string{name})
+	m.Projection = expr.NewProjection()
+	m.Projection.AddColumnShort(name, value.StringType)
+	tasks := make(Tasks, 0)
+	sourceTask := NewSource(nil, source)
+	tasks.Add(sourceTask)
+	return NewSequential(name, tasks), expr.VisitContinue, nil
+}
+
+func (m *JobBuilder) VisitShow(stmt *expr.SqlShow) (expr.Task, expr.VisitStatus, error) {
+	u.Debugf("VisitShow %q  %s", stmt.Identity, stmt.Raw)
+
+	raw := strings.ToLower(stmt.Raw)
+	switch {
+	case strings.ToLower(stmt.Identity) == "variables":
+		// SHOW variables;
+		vals := make([][]driver.Value, 2)
+		vals[0] = []driver.Value{"auto_increment_increment", "1"}
+		vals[1] = []driver.Value{"collation", "utf8"}
+		source := membtree.NewStaticDataSource("variables", 0, vals, []string{"Variable_name", "Value"})
+		m.Projection = expr.NewProjection()
+		m.Projection.AddColumnShort("Variable_name", value.StringType)
+		m.Projection.AddColumnShort("Value", value.StringType)
+		tasks := make(Tasks, 0)
+		sourceTask := NewSource(nil, source)
+		u.Infof("source:  %#v", source)
+		tasks.Add(sourceTask)
+		return NewSequential("variables", tasks), expr.VisitContinue, nil
+	case strings.ToLower(stmt.Identity) == "databases":
+		// SHOW databases;
+		vals := make([][]driver.Value, 1)
+		vals[0] = []driver.Value{m.connInfo}
+		source := membtree.NewStaticDataSource("databases", 0, vals, []string{"Database"})
+		m.Projection = expr.NewProjection()
+		m.Projection.AddColumnShort("Database", value.StringType)
+		tasks := make(Tasks, 0)
+		sourceTask := NewSource(nil, source)
+		u.Infof("source:  %#v", source)
+		tasks.Add(sourceTask)
+		return NewSequential("databases", tasks), expr.VisitContinue, nil
+	case strings.ToLower(stmt.Identity) == "collation":
+		// SHOW collation;
+		vals := make([][]driver.Value, 1)
+		// utf8_general_ci          | utf8     |  33 | Yes     | Yes      |       1 |
+		vals[0] = []driver.Value{"utf8_general_ci", "utf8", 33, "Yes", "Yes", 1}
+		cols := []string{"Collation", "Charset", "Id", "Default", "Compiled", "Sortlen"}
+		source := membtree.NewStaticDataSource("collation", 0, vals, cols)
+		m.Projection = expr.NewProjection()
+		m.Projection.AddColumnShort("Collation", value.StringType)
+		m.Projection.AddColumnShort("Charset", value.StringType)
+		m.Projection.AddColumnShort("Id", value.IntType)
+		m.Projection.AddColumnShort("Default", value.StringType)
+		m.Projection.AddColumnShort("Compiled", value.StringType)
+		m.Projection.AddColumnShort("Sortlen", value.IntType)
+		tasks := make(Tasks, 0)
+		sourceTask := NewSource(nil, source)
+		u.Infof("source:  %#v", source)
+		tasks.Add(sourceTask)
+		return NewSequential("collation", tasks), expr.VisitContinue, nil
+	case strings.HasPrefix(raw, "show session"):
+		//SHOW SESSION VARIABLES LIKE 'lower_case_table_names';
+		source, proj := ShowVariables("lower_case_table_names", 0)
+		m.Projection = proj
+		tasks := make(Tasks, 0)
+		sourceTask := NewSource(nil, source)
+		u.Infof("source:  %#v", source)
+		tasks.Add(sourceTask)
+		return NewSequential("session", tasks), expr.VisitContinue, nil
+	case strings.ToLower(stmt.Identity) == "tables" || strings.ToLower(stmt.Identity) == m.connInfo:
+		if stmt.Full {
+			u.Debugf("show tables: %+v", m.Conf)
+			tables := m.Conf.Tables()
+			vals := make([][]driver.Value, len(tables))
+			row := 0
+			for _, tbl := range tables {
+				vals[row] = []driver.Value{tbl, "BASE TABLE"}
+				row++
+			}
+			source := membtree.NewStaticDataSource("tables", 0, vals, []string{"Tables", "Table_type"})
+			m.Projection = expr.NewProjection()
+			m.Projection.AddColumnShort("Tables", value.StringType)
+			m.Projection.AddColumnShort("Table_type", value.StringType)
+			tasks := make(Tasks, 0)
+			sourceTask := NewSource(nil, source)
+			u.Infof("source:  %#v", source)
+			tasks.Add(sourceTask)
+			return NewSequential("show-tables", tasks), expr.VisitContinue, nil
+		}
+		// SHOW TABLES;
+		//u.Debugf("show tables: %+v", m.Conf)
+		source, proj := ShowTables(m.Conf)
+		m.Projection = proj
+		tasks := make(Tasks, 0)
+		sourceTask := NewSource(nil, source)
+		//u.Infof("source:  %#v", source)
+		tasks.Add(sourceTask)
+		return NewSequential("describe", tasks), expr.VisitContinue, nil
+	case strings.ToLower(stmt.Identity) == "procedure":
+		// SHOW PROCEDURE STATUS WHERE Db='mydb'
+		return m.emptyTask("Procedures")
+	case strings.ToLower(stmt.Identity) == "function":
+		// SHOW FUNCTION STATUS WHERE Db='mydb'
+		return m.emptyTask("Function")
+	default:
+		// SHOW FULL TABLES FROM `auths`
+		desc := expr.SqlDescribe{}
+		desc.Identity = stmt.Identity
+		return m.VisitDescribe(&desc)
+	}
+	return nil, expr.VisitError, fmt.Errorf("No handler found")
+}
+
+func (m *JobBuilder) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, expr.VisitStatus, error) {
+	u.Debugf("VisitDescribe %+v", stmt)
+
+	if m.Conf == nil {
+		return nil, expr.VisitError, ErrNoSchemaSelected
+	}
+	tbl, err := m.Conf.Table(strings.ToLower(stmt.Identity))
+	if err != nil {
+		u.Errorf("could not get table: %v", err)
+		return nil, expr.VisitError, err
+	}
+	source, proj := DescribeTable(tbl)
+	m.Projection = proj
+
+	tasks := make(Tasks, 0)
+	sourceTask := NewSource(nil, source)
+	u.Infof("source:  %#v", source)
+	tasks.Add(sourceTask)
+
+	return NewSequential("describe", tasks), expr.VisitContinue, nil
+}

--- a/exec/engine.go
+++ b/exec/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/plan"
 )
 
 var (
@@ -37,7 +38,7 @@ type SqlJob struct {
 	RootTask   TaskRunner
 	Stmt       expr.SqlStatement
 	Schema     *datasource.Schema
-	Projection *expr.Projection
+	Projection *plan.Projection
 	Conf       *datasource.RuntimeSchema
 }
 
@@ -63,6 +64,7 @@ func (m *SqlJob) DrainChan() MessageChan {
 
 // Create Job made up of sub-tasks in DAG that is the
 //  plan for execution of this query/job
+//  include the projection
 func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText string) (*SqlJob, error) {
 
 	job, err := BuildSqlJob(conf, connInfo, sqlText)
@@ -74,7 +76,8 @@ func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText stri
 		return job, nil
 	}
 	if sqlSelect, ok := job.Stmt.(*expr.SqlSelect); ok {
-		job.Projection, err = NewExprProjection(conf, sqlSelect, true)
+		//job.Projection, err = NewExprProjection(conf, sqlSelect, true)
+		job.Projection, err = plan.NewProjectionFinal(conf, sqlSelect)
 		if err != nil {
 			return nil, err
 		}

--- a/exec/engine.go
+++ b/exec/engine.go
@@ -70,6 +70,7 @@ func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText stri
 		return job, err
 	}
 	if job.Projection != nil {
+		//u.Warnf("return job.proj: %p", job.Projection)
 		return job, nil
 	}
 	if sqlSelect, ok := job.Stmt.(*expr.SqlSelect); ok {
@@ -91,6 +92,8 @@ func BuildSqlJob(conf *datasource.RuntimeSchema, connInfo, sqlText string) (*Sql
 
 	builder := NewJobBuilder(conf, connInfo)
 	task, _, err := stmt.Accept(builder)
+
+	//u.Debugf("build sqljob.proj: %p", builder.Projection)
 
 	if err != nil {
 		return nil, err

--- a/exec/engine.go
+++ b/exec/engine.go
@@ -74,13 +74,10 @@ func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText stri
 		return job, nil
 	}
 	if sqlSelect, ok := job.Stmt.(*expr.SqlSelect); ok {
-		job.Projection, err = NewExprProjection(conf, sqlSelect)
+		job.Projection, err = NewExprProjection(conf, sqlSelect, true)
 		if err != nil {
 			return nil, err
 		}
-		// if err = createProjection(job, sqlSelect); err != nil {
-		// 	return nil, err
-		// }
 	}
 	return job, nil
 }
@@ -89,7 +86,7 @@ func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText stri
 //  plan for execution of this query/job
 func BuildSqlJob(conf *datasource.RuntimeSchema, connInfo, sqlText string) (*SqlJob, error) {
 
-	stmt, err := expr.ParseSqlVm(sqlText)
+	stmt, err := expr.ParseSql(sqlText)
 	if err != nil {
 		return nil, err
 	}

--- a/exec/engine.go
+++ b/exec/engine.go
@@ -74,9 +74,13 @@ func BuildSqlProjectedJob(conf *datasource.RuntimeSchema, connInfo, sqlText stri
 		return job, nil
 	}
 	if sqlSelect, ok := job.Stmt.(*expr.SqlSelect); ok {
-		if err = createProjection(job, sqlSelect); err != nil {
+		job.Projection, err = NewExprProjection(conf, sqlSelect)
+		if err != nil {
 			return nil, err
 		}
+		// if err = createProjection(job, sqlSelect); err != nil {
+		// 	return nil, err
+		// }
 	}
 	return job, nil
 }

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -73,9 +73,9 @@ func TestEngineWhere(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 	assert.Tf(t, err == nil, "no error %v", err)
 	assert.Tf(t, len(msgs) == 1, "should have filtered out 2 messages %v", len(msgs))
-	u.Infof("msg: %#v", msgs[0])
+	u.Debugf("msg: %#v", msgs[0])
 	row := msgs[0].(*datasource.SqlDriverMessageMap).Values()
-	u.Infof("row: %#v", row)
+	u.Debugf("row: %#v", row)
 	assert.Tf(t, len(row) == 5, "expects 5 cols but got %v", len(row))
 	assert.T(t, row[0] == "9Ip1aKbeZe2njCDM")
 	// I really don't like this float behavior?

--- a/exec/exec_test.go
+++ b/exec/exec_test.go
@@ -57,7 +57,7 @@ func init() {
 func TestEngineWhere(t *testing.T) {
 	sqlText := `
 		select 
-	        user_id, email, referral_count * 2, yy(reg_date) > 10
+	        user_id, email, referral_count * 2, 5, yy(reg_date) > 10
 	    FROM users
 	    WHERE yy(reg_date) > 10 
 	`
@@ -74,6 +74,15 @@ func TestEngineWhere(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 	assert.Tf(t, err == nil, "no error %v", err)
 	assert.Tf(t, len(msgs) == 1, "should have filtered out 2 messages %v", len(msgs))
+	u.Infof("msg: %#v", msgs[0])
+	row := msgs[0].(*datasource.SqlDriverMessageMap).Values()
+	u.Infof("row: %#v", row)
+	assert.Tf(t, len(row) == 5, "expects 5 cols but got %v", len(row))
+	assert.T(t, row[0] == "9Ip1aKbeZe2njCDM")
+	// I really don't like this float behavior?
+	assert.Tf(t, int(row[2].(float64)) == 164, "expected %v == 164  T:%T", row[2], row[2])
+	assert.Tf(t, row[3] == int64(5), "wanted 5 got %v  T:%T", row[3], row[3])
+	assert.T(t, row[4] == true)
 }
 
 type UserEvent struct {

--- a/exec/join.go
+++ b/exec/join.go
@@ -92,7 +92,7 @@ func (m *JoinKey) Run(context *expr.Context) error {
 						}
 						vals[i] = joinVal.ToString()
 					}
-					u.Infof("joinkey: %v", vals)
+					//u.Infof("joinkey: %v row:%v", vals, mt.Row())
 					key := strings.Join(vals, string(byte(0)))
 					mt.SetKeyHashed(key)
 					outCh <- mt
@@ -172,12 +172,12 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 	for _, col := range m.leftStmt.Source.Columns {
 		//u.Debugf("left col:  idx=%d  key=%q as=%q col=%v parentidx=%v", len(m.colIndex), col.Key(), col.As, col.String(), col.ParentIndex)
 		m.colIndex[m.leftStmt.Alias+"."+col.Key()] = col.ParentIndex
-		u.Debugf("left  colIndex:  %15q : idx:%d sidx:%d pidx:%d", m.leftStmt.Alias+"."+col.Key(), col.Index, col.SourceIndex, col.ParentIndex)
+		//u.Debugf("left  colIndex:  %15q : idx:%d sidx:%d pidx:%d", m.leftStmt.Alias+"."+col.Key(), col.Index, col.SourceIndex, col.ParentIndex)
 	}
 	for _, col := range m.rightStmt.Source.Columns {
 		//u.Debugf("right col:  idx=%d  key=%q as=%q col=%v", len(m.colIndex), col.Key(), col.As, col.String())
 		m.colIndex[m.rightStmt.Alias+"."+col.Key()] = col.ParentIndex
-		u.Debugf("right colIndex:  %15q : idx:%d sidx:%d pidx:%d", m.rightStmt.Alias+"."+col.Key(), col.Index, col.SourceIndex, col.ParentIndex)
+		//u.Debugf("right colIndex:  %15q : idx:%d sidx:%d pidx:%d", m.rightStmt.Alias+"."+col.Key(), col.Index, col.SourceIndex, col.ParentIndex)
 	}
 
 	// lcols := m.leftStmt.Source.AliasedColumns()
@@ -202,7 +202,7 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 				return
 			case msg, ok := <-leftIn:
 				if !ok {
-					u.Debugf("NICE, got left shutdown")
+					//u.Debugf("NICE, got left shutdown")
 					wg.Done()
 					return
 				} else {
@@ -240,7 +240,7 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 				return
 			case msg, ok := <-rightIn:
 				if !ok {
-					u.Debugf("NICE, got right shutdown")
+					//u.Debugf("NICE, got right shutdown")
 					wg.Done()
 					return
 				} else {
@@ -326,8 +326,8 @@ func (m *JoinMerge) valIndexing(valOut, valSource []driver.Value, cols []*expr.C
 		if col.Index < 0 || col.Index >= len(valSource) {
 			u.Errorf("source index out of range? idx:%v of %d  source: %#v  \n\tcol=%#v", col.Index, len(valSource), valSource, col)
 		}
-		u.Infof("found: si=%v pi:%v idx:%d as=%v vals:%v", col.SourceIndex, col.ParentIndex, col.Index, col.As, valSource)
-		valOut[col.ParentIndex] = valSource[col.SourceIndex]
+		//u.Infof("found: si=%v pi:%v idx:%d as=%v vals:%v len(out):%v", col.SourceIndex, col.ParentIndex, col.Index, col.As, valSource, len(valOut))
+		valOut[col.ParentIndex] = valSource[col.Index]
 	}
 	return valOut
 }

--- a/exec/join.go
+++ b/exec/join.go
@@ -196,10 +196,12 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 			select {
 			case <-m.SigChan():
 				u.Warnf("got signal quit")
+				wg.Done()
+				wg.Done()
 				return
 			case msg, ok := <-leftIn:
 				if !ok {
-					//u.Warnf("NICE, got left shutdown")
+					u.Warnf("NICE, got left shutdown")
 					wg.Done()
 					return
 				} else {
@@ -208,12 +210,14 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 						key := mt.Key()
 						if key == "" {
 							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt.Row())
+							u.Errorf("no key? %#v  %v", mt, fatalErr)
 							close(m.TaskBase.sigCh)
 							return
 						}
 						lh[key] = append(lh[key], mt)
 					default:
 						fatalErr = fmt.Errorf("To use Join must use SqlDriverMessageMap but got %T", msg)
+						u.Errorf("unrecognized msg %T", msg)
 						close(m.TaskBase.sigCh)
 						return
 					}
@@ -230,10 +234,12 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 			select {
 			case <-m.SigChan():
 				u.Warnf("got quit signal join source 1")
+				wg.Done()
+				wg.Done()
 				return
 			case msg, ok := <-rightIn:
 				if !ok {
-					//u.Warnf("NICE, got right shutdown")
+					u.Warnf("NICE, got right shutdown")
 					wg.Done()
 					return
 				} else {
@@ -242,12 +248,14 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 						key := mt.Key()
 						if key == "" {
 							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt.Row())
+							u.Errorf("no key? %#v  %v", mt, fatalErr)
 							close(m.TaskBase.sigCh)
 							return
 						}
 						rh[key] = append(rh[key], mt)
 					default:
 						fatalErr = fmt.Errorf("To use Join must use SqlDriverMessageMap but got %T", msg)
+						u.Errorf("unrecognized msg %T", msg)
 						close(m.TaskBase.sigCh)
 						return
 					}

--- a/exec/join.go
+++ b/exec/join.go
@@ -92,6 +92,7 @@ func (m *JoinKey) Run(context *expr.Context) error {
 						}
 						vals[i] = joinVal.ToString()
 					}
+					u.Infof("joinkey: %v", vals)
 					key := strings.Join(vals, string(byte(0)))
 					mt.SetKeyHashed(key)
 					outCh <- mt
@@ -325,7 +326,7 @@ func (m *JoinMerge) valIndexing(valOut, valSource []driver.Value, cols []*expr.C
 		if col.Index < 0 || col.Index >= len(valSource) {
 			u.Errorf("source index out of range? idx:%v of %d  source: %#v  \n\tcol=%#v", col.Index, len(valSource), valSource, col)
 		}
-		//u.Infof("found: i=%v pi:%v as=%v	val=%v	source:%v", col.SourceIndex, col.ParentIndex, col.As, valSource[col.SourceIndex], valSource)
+		u.Infof("found: si=%v pi:%v idx:%d as=%v vals:%v", col.SourceIndex, col.ParentIndex, col.Index, col.As, valSource)
 		valOut[col.ParentIndex] = valSource[col.SourceIndex]
 	}
 	return valOut

--- a/exec/join.go
+++ b/exec/join.go
@@ -195,13 +195,13 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 			//u.Infof("In source Scanner msg %#v", msg)
 			select {
 			case <-m.SigChan():
-				u.Warnf("got signal quit")
+				u.Debugf("got signal quit")
 				wg.Done()
 				wg.Done()
 				return
 			case msg, ok := <-leftIn:
 				if !ok {
-					u.Warnf("NICE, got left shutdown")
+					u.Debugf("NICE, got left shutdown")
 					wg.Done()
 					return
 				} else {
@@ -233,13 +233,13 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 			//u.Infof("In source Scanner iter %#v", item)
 			select {
 			case <-m.SigChan():
-				u.Warnf("got quit signal join source 1")
+				u.Debugf("got quit signal join source 1")
 				wg.Done()
 				wg.Done()
 				return
 			case msg, ok := <-rightIn:
 				if !ok {
-					u.Warnf("NICE, got right shutdown")
+					u.Debugf("NICE, got right shutdown")
 					wg.Done()
 					return
 				} else {

--- a/exec/mutations.go
+++ b/exec/mutations.go
@@ -189,7 +189,7 @@ func (m *Upsert) insertRows(ctx *expr.Context, rows [][]*expr.ValueColumn) (int6
 
 			//u.Debugf("db.Put()  db:%T   %v", m.db, vals)
 			if _, err := m.db.Put(ctx, nil, vals); err != nil {
-				u.Errorf("Could not put values: %v", err)
+				u.Errorf("Could not put values: fordb T:%T  %v", m.db, err)
 				return 0, err
 			}
 			// continue

--- a/exec/mutations.go
+++ b/exec/mutations.go
@@ -239,7 +239,7 @@ func (m *DeletionTask) Close() error {
 func (m *DeletionTask) Run(context *expr.Context) error {
 	defer context.Recover()
 	defer close(m.msgOutCh)
-	u.Infof("In Delete Task expr:: %s", m.sql.Where)
+	u.Debugf("In Delete Task expr:: %s", m.sql.Where)
 
 	deletedCt, err := m.db.DeleteExpression(m.sql.Where)
 	if err != nil {
@@ -259,7 +259,7 @@ func (m *DeletionScanner) Run(context *expr.Context) error {
 	defer context.Recover()
 	defer close(m.msgOutCh)
 
-	u.Infof("In Delete Scanner expr %#v", m.sql.Where)
+	u.Debugf("In Delete Scanner expr %#v", m.sql.Where)
 	select {
 	case <-m.SigChan():
 		return nil

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -30,6 +30,7 @@ func (m *Projection) projectionEvaluator() MessageHandler {
 	out := m.MessageOut()
 	columns := m.sql.Columns
 	colIndex := m.sql.ColIndexes()
+	u.Infof("%p projection cols: %v  %s", m, colIndex, m.sql.String())
 	// if len(m.sql.From) > 1 && m.sql.From[0].Source != nil && len(m.sql.From[0].Source.Columns) > 0 {
 	// 	// we have re-written this query, lets build new list of columns
 	// 	columns = make(expr.Columns, 0)
@@ -59,7 +60,7 @@ func (m *Projection) projectionEvaluator() MessageHandler {
 				if col.ParentIndex < 0 {
 					continue
 				}
-				//u.Debugf("col: idx:%v pidx:%v key:%v   %s", col.Index, col.ParentIndex, col.Key(), col.Expr)
+				u.Debugf("col: idx:%v pidx:%v key:%v   %s", col.Index, col.ParentIndex, col.Key(), col.Expr)
 				if col.Guard != nil {
 					ifColValue, ok := vm.Eval(mt, col.Guard)
 					if !ok {

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -103,14 +103,17 @@ func (m *Projection) projectionEvaluator(isFinal bool) MessageHandler {
 						//writeContext.Put(&expr.Column{As: k}, nil, value.NewValue(v))
 						row[i+colCt] = v
 					}
+				} else if col.Expr == nil {
+					u.Warnf("wat?   nil col expr? %+v", col)
 				} else {
 					v, ok := vm.Eval(mt, col.Expr)
 					if !ok {
 						u.Warnf("failed eval key=%v  val=%#v expr:%s   mt:%#v", col.Key(), v, col.Expr, mt)
 					} else if v == nil {
-						//u.Debugf("evaled: key=%v  val=%v", col.Key(), v)
+						u.Debugf("%#v", col)
+						u.Debugf("evaled nil? key=%v  val=%v expr:%s", col.Key(), v, col.Expr.String())
 						//writeContext.Put(col, mt, v)
-						row[i+colCt] = v.Value()
+						row[i+colCt] = nil //v.Value()
 					} else {
 						//u.Debugf("evaled: key=%v  val=%v", col.Key(), v.Value())
 						//writeContext.Put(col, mt, v)

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -75,7 +75,7 @@ func (m *Projection) projectionEvaluator(isFinal bool) MessageHandler {
 				if col.ParentIndex < 0 {
 					continue
 				}
-				u.Debugf("col: idx:%v pidx:%v key:%v   %s", col.Index, col.ParentIndex, col.Key(), col.Expr)
+				//u.Debugf("col: idx:%v pidx:%v key:%v   %s", col.Index, col.ParentIndex, col.Key(), col.Expr)
 				if col.Guard != nil {
 					ifColValue, ok := vm.Eval(mt, col.Guard)
 					if !ok {

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -45,7 +45,7 @@ func (m *Projection) projectionEvaluator(isFinal bool) MessageHandler {
 	out := m.MessageOut()
 	columns := m.sql.Columns
 	colIndex := m.sql.ColIndexes()
-	u.Infof("projection: %p cols ct:%d index:%v  %s", m, len(columns), colIndex, m.sql.String())
+	u.Debugf("projection: %p cols ct:%d index:%v  %s", m, len(columns), colIndex, m.sql.String())
 	// if len(m.sql.From) > 1 && m.sql.From[0].Source != nil && len(m.sql.From[0].Source.Columns) > 0 {
 	// 	// we have re-written this query, lets build new list of columns
 	// 	columns = make(expr.Columns, 0)
@@ -173,6 +173,7 @@ func (m *Projection) projectionEvaluator(isFinal bool) MessageHandler {
 		}
 	}
 }
+
 func NewExprProjection(conf *datasource.RuntimeSchema, stmt *expr.SqlSelect, isFinal bool) (*expr.Projection, error) {
 
 	if len(stmt.From) == 0 {

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -120,6 +120,7 @@ func (m *Projection) projectionEvaluator(isFinal bool) MessageHandler {
 						u.Debugf("%#v", col)
 						u.Debugf("evaled nil? key=%v  val=%v expr:%s", col.Key(), v, col.Expr.String())
 						//writeContext.Put(col, mt, v)
+						u.Infof("mt: %T  mt %#v", mt, mt)
 						row[i+colCt] = nil //v.Value()
 					} else {
 						//u.Debugf("evaled: key=%v  val=%v", col.Key(), v.Value())

--- a/exec/projection.go
+++ b/exec/projection.go
@@ -1,7 +1,10 @@
 package exec
 
 import (
+	"database/sql/driver"
+
 	u "github.com/araddon/gou"
+
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
@@ -26,6 +29,7 @@ func NewProjection(sqlSelect *expr.SqlSelect) *Projection {
 func (m *Projection) projectionEvaluator() MessageHandler {
 	out := m.MessageOut()
 	columns := m.sql.Columns
+	colIndex := m.sql.ColIndexes()
 	// if len(m.sql.From) > 1 && m.sql.From[0].Source != nil && len(m.sql.From[0].Source.Columns) > 0 {
 	// 	// we have re-written this query, lets build new list of columns
 	// 	columns = make(expr.Columns, 0)
@@ -48,10 +52,10 @@ func (m *Projection) projectionEvaluator() MessageHandler {
 		case *datasource.SqlDriverMessageMap:
 			// readContext := datasource.NewContextUrlValues(uv)
 			// use our custom write context for example purposes
-			writeContext := datasource.NewContextSimple()
-			outMsg = writeContext
+			row := make([]driver.Value, len(columns))
 			//u.Debugf("about to project: %#v", mt)
-			for _, col := range columns {
+			colCt := 0
+			for i, col := range columns {
 				if col.ParentIndex < 0 {
 					continue
 				}
@@ -72,60 +76,74 @@ func (m *Projection) projectionEvaluator() MessageHandler {
 					}
 				}
 				if col.Star {
-					for k, v := range mt.Row() {
-						writeContext.Put(&expr.Column{As: k}, nil, value.NewValue(v))
+					starRow := mt.Row()
+					newRow := make([]driver.Value, len(starRow)+len(colIndex))
+					for curi := 0; curi < i; curi++ {
+						newRow[curi] = row[curi]
+					}
+					row = newRow
+					for _, v := range starRow {
+						colCt += 1
+						//writeContext.Put(&expr.Column{As: k}, nil, value.NewValue(v))
+						row[i+colCt] = v
 					}
 				} else {
 					v, ok := vm.Eval(mt, col.Expr)
 					if !ok {
 						u.Warnf("failed eval key=%v  val=%#v expr:%s   mt:%#v", col.Key(), v, col.Expr, mt)
 					} else if v == nil {
-						u.Debugf("evaled: key=%v  val=%v", col.Key(), v)
-						writeContext.Put(col, mt, v)
+						//u.Debugf("evaled: key=%v  val=%v", col.Key(), v)
+						//writeContext.Put(col, mt, v)
+						row[i+colCt] = v.Value()
 					} else {
 						//u.Debugf("evaled: key=%v  val=%v", col.Key(), v.Value())
-						writeContext.Put(col, mt, v)
+						//writeContext.Put(col, mt, v)
+						row[i+colCt] = v.Value()
 					}
 				}
 			}
-
-		case *datasource.ContextUrlValues:
-			// readContext := datasource.NewContextUrlValues(uv)
-			// use our custom write context for example purposes
-			writeContext := datasource.NewContextSimple()
-			outMsg = writeContext
-			//u.Infof("about to project: colsct%v %#v", len(sql.Columns), outMsg)
-			for _, col := range columns {
-				//u.Debugf("col:   %#v", col)
-				if col.Guard != nil {
-					ifColValue, ok := vm.Eval(mt, col.Guard)
-					if !ok {
-						u.Errorf("Could not evaluate if:   %v", col.Guard.String())
-						//return fmt.Errorf("Could not evaluate if clause: %v", col.Guard.String())
-					}
-					//u.Debugf("if eval val:  %T:%v", ifColValue, ifColValue)
-					switch ifColVal := ifColValue.(type) {
-					case value.BoolValue:
-						if ifColVal.Val() == false {
-							//u.Debugf("Filtering out col")
-							continue
+			//u.Infof("row: %#v", row)
+			//u.Infof("row cols: %v", colIndex)
+			outMsg = datasource.NewSqlDriverMessageMap(0, row, colIndex)
+		/*
+			case *datasource.ContextUrlValues:
+				// readContext := datasource.NewContextUrlValues(uv)
+				// use our custom write context for example purposes
+				writeContext := datasource.NewContextSimple()
+				outMsg = writeContext
+				//u.Infof("about to project: colsct%v %#v", len(sql.Columns), outMsg)
+				for _, col := range columns {
+					//u.Debugf("col:   %#v", col)
+					if col.Guard != nil {
+						ifColValue, ok := vm.Eval(mt, col.Guard)
+						if !ok {
+							u.Errorf("Could not evaluate if:   %v", col.Guard.String())
+							//return fmt.Errorf("Could not evaluate if clause: %v", col.Guard.String())
+						}
+						//u.Debugf("if eval val:  %T:%v", ifColValue, ifColValue)
+						switch ifColVal := ifColValue.(type) {
+						case value.BoolValue:
+							if ifColVal.Val() == false {
+								//u.Debugf("Filtering out col")
+								continue
+							}
 						}
 					}
-				}
-				if col.Star {
-					for k, v := range mt.Row() {
-						writeContext.Put(&expr.Column{As: k}, nil, v)
+					if col.Star {
+						for k, v := range mt.Row() {
+							writeContext.Put(&expr.Column{As: k}, nil, v)
+						}
+					} else {
+						//u.Debugf("tree.Root: as?%v %#v", col.As, col.Expr)
+						v, ok := vm.Eval(mt, col.Expr)
+						//u.Debugf("evaled: ok?%v key=%v  val=%v", ok, col.Key(), v)
+						if ok {
+							writeContext.Put(col, mt, v)
+						}
 					}
-				} else {
-					//u.Debugf("tree.Root: as?%v %#v", col.As, col.Expr)
-					v, ok := vm.Eval(mt, col.Expr)
-					//u.Debugf("evaled: ok?%v key=%v  val=%v", ok, col.Key(), v)
-					if ok {
-						writeContext.Put(col, mt, v)
-					}
-				}
 
-			}
+				}
+		*/
 		default:
 			u.Errorf("could not project msg:  %T", msg)
 		}

--- a/exec/results.go
+++ b/exec/results.go
@@ -105,7 +105,7 @@ func (m *ResultBuffer) Close() error                { return nil }
 
 // Note, this is implementation of the sql/driver Rows() Next() interface
 func (m *ResultWriter) Next(dest []driver.Value) error {
-	u.Debugf("resultwriter.Next()")
+	//u.Debugf("resultwriter.Next()")
 	select {
 	case <-m.SigChan():
 		return ErrShuttingDown
@@ -116,7 +116,7 @@ func (m *ResultWriter) Next(dest []driver.Value) error {
 			return io.EOF
 		}
 		if msg == nil {
-			u.Warnf("nil message?")
+			//u.Warnf("nil message?")
 			return io.EOF
 			//return fmt.Errorf("Nil message error?")
 		}
@@ -134,7 +134,7 @@ func (m *ResultWriter) Run(ctx *expr.Context) error {
 		close(m.msgOutCh) // closing output channels is the signal to stop
 		//u.Warnf("close taskbase: %v", m.Type())
 	}()
-	u.Debugf("start Run() for ResultWriter")
+	//u.Debugf("start Run() for ResultWriter")
 	select {
 	case err := <-m.errCh:
 		u.Errorf("got error:  %v", err)

--- a/exec/results.go
+++ b/exec/results.go
@@ -105,7 +105,7 @@ func (m *ResultBuffer) Close() error                { return nil }
 
 // Note, this is implementation of the sql/driver Rows() Next() interface
 func (m *ResultWriter) Next(dest []driver.Value) error {
-	//u.Debugf("resultwriter.Next()")
+	u.Debugf("resultwriter.Next()")
 	select {
 	case <-m.SigChan():
 		return ErrShuttingDown
@@ -134,7 +134,7 @@ func (m *ResultWriter) Run(ctx *expr.Context) error {
 		close(m.msgOutCh) // closing output channels is the signal to stop
 		//u.Warnf("close taskbase: %v", m.Type())
 	}()
-	//u.Debugf("start Run() for ResultWriter")
+	u.Debugf("start Run() for ResultWriter")
 	select {
 	case err := <-m.errCh:
 		u.Errorf("got error:  %v", err)

--- a/exec/results.go
+++ b/exec/results.go
@@ -108,7 +108,7 @@ func (m *ResultWriter) Next(dest []driver.Value) error {
 	//u.Debugf("resultwriter.Next()")
 	select {
 	case <-m.SigChan():
-		return ShuttingDownError
+		return ErrShuttingDown
 	case err := <-m.ErrChan():
 		return err
 	case msg, ok := <-m.MessageIn():

--- a/exec/results.go
+++ b/exec/results.go
@@ -172,17 +172,33 @@ func msgToRow(msg datasource.Message, cols []string, dest []driver.Value) error 
 
 	//u.Debugf("msg? %v  %T \n%p %v", msg, msg, dest, dest)
 	switch mt := msg.Body().(type) {
-	case *datasource.ContextUrlValues:
-		for i, key := range cols {
-			if val, ok := mt.Get(key); ok && !val.Nil() {
-				dest[i] = val.Value()
-				//u.Infof("key=%v   val=%v", key, val)
-			} else {
-				u.Warnf("missing value? %v %T %v", key, val.Value(), val.Value())
+	/*
+		case *datasource.ContextUrlValues:
+			for i, key := range cols {
+				if val, ok := mt.Get(key); ok && !val.Nil() {
+					dest[i] = val.Value()
+					//u.Infof("key=%v   val=%v", key, val)
+				} else {
+					u.Warnf("missing value? %v %T %v", key, val.Value(), val.Value())
+				}
 			}
-		}
-		//u.Debugf("got msg in row result writer: %#v", mt)
-	case *datasource.ContextSimple:
+			//u.Debugf("got msg in row result writer: %#v", mt)
+
+		case *datasource.ContextSimple:
+			for i, key := range cols {
+				//u.Debugf("key=%v mt = nil? %v", key, mt)
+				if val, ok := mt.Get(key); ok && val != nil && !val.Nil() {
+					dest[i] = val.Value()
+					//u.Infof("key=%v   val=%v", key, val)
+				} else if val == nil {
+					u.Errorf("could not evaluate? %v  %#v", key, mt.Row())
+				} else {
+					u.Warnf("missing value? %v %T %v", key, val.Value(), val.Value())
+				}
+			}
+			//u.Debugf("got msg in row result writer: %#v", dest)
+	*/
+	case *datasource.SqlDriverMessageMap:
 		for i, key := range cols {
 			//u.Debugf("key=%v mt = nil? %v", key, mt)
 			if val, ok := mt.Get(key); ok && val != nil && !val.Nil() {

--- a/exec/source.go
+++ b/exec/source.go
@@ -15,33 +15,7 @@ var (
 	// Ensure that we implement the Task Runner interface
 	// to ensure this can run in exec engine
 	_ TaskRunner = (*Source)(nil)
-
-	// Ensure that our source plan implements Subvisitor
-	_ expr.SubVisitor = (*SourcePlan)(nil)
 )
-
-// ??? is this used?
-func NewSourcePlan(sql *expr.SqlSource) *SourcePlan {
-	return &SourcePlan{SqlSource: sql}
-}
-
-type SourcePlan struct {
-	SqlSource *expr.SqlSource
-}
-
-func (m *SourcePlan) Accept(sub expr.SubVisitor) (expr.Task, error) {
-	u.Debugf("Accept %+v", sub)
-	return nil, expr.ErrNotImplemented
-}
-func (m *SourcePlan) VisitSubselect(stmt *expr.SqlSource) (expr.Task, error) {
-	u.Debugf("VisitSubselect %+v", stmt)
-	return nil, expr.ErrNotImplemented
-}
-
-func (m *SourcePlan) VisitJoin(stmt *expr.SqlSource) (expr.Task, error) {
-	u.Debugf("VisitJoin %+v", stmt)
-	return nil, expr.ErrNotImplemented
-}
 
 // Scan a data source for rows, feed into runner.  The source scanner being
 //   a source is iter.Next() messages instead of sending them on input channel

--- a/exec/source_where_test.go
+++ b/exec/source_where_test.go
@@ -63,7 +63,7 @@ func buildSource(t *testing.T, conf *datasource.RuntimeSchema, connInfo, sqlText
 
 	// Note, we are doing a custom Job Plan here to
 	//   isolate and test just the Source/Where
-	srcPlan, err := plan.NewSourcePlan(conf, sql.From[0])
+	srcPlan, err := plan.NewSourcePlan(conf, sql.From[0], true)
 	assert.T(t, err == nil, "got error? ", err)
 	task, _, err := job.VisitSourceSelect(srcPlan)
 	assert.T(t, err == nil)

--- a/exec/source_where_test.go
+++ b/exec/source_where_test.go
@@ -62,7 +62,7 @@ func buildSource(t *testing.T, conf *datasource.RuntimeSchema, connInfo, sqlText
 
 	// Note, we are doing a custom Job Plan here to
 	//   isolate and test just the Source/Where
-	task, err := job.VisitSubselect(sql.From[0])
+	task, err := job.VisitSubSelect(sql.From[0])
 	assert.T(t, err == nil)
 
 	tasks.Add(task.(TaskRunner))

--- a/exec/source_where_test.go
+++ b/exec/source_where_test.go
@@ -62,7 +62,7 @@ func buildSource(t *testing.T, conf *datasource.RuntimeSchema, connInfo, sqlText
 
 	// Note, we are doing a custom Job Plan here to
 	//   isolate and test just the Source/Where
-	task, err := job.VisitSubSelect(sql.From[0])
+	task, _, err := job.VisitSubSelect(sql.From[0])
 	assert.T(t, err == nil)
 
 	tasks.Add(task.(TaskRunner))

--- a/exec/source_where_test.go
+++ b/exec/source_where_test.go
@@ -69,5 +69,5 @@ func buildSource(t *testing.T, conf *datasource.RuntimeSchema, connInfo, sqlText
 	tasks.Add(rw)
 
 	taskRoot := NewSequential("select", tasks)
-	return &SqlJob{taskRoot, stmt, conf}
+	return &SqlJob{RootTask: taskRoot, Stmt: stmt, Conf: conf}
 }

--- a/exec/source_where_test.go
+++ b/exec/source_where_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/plan"
 )
 
 var (
@@ -62,7 +63,9 @@ func buildSource(t *testing.T, conf *datasource.RuntimeSchema, connInfo, sqlText
 
 	// Note, we are doing a custom Job Plan here to
 	//   isolate and test just the Source/Where
-	task, _, err := job.VisitSubSelect(sql.From[0])
+	srcPlan, err := plan.NewSourcePlan(conf, sql.From[0])
+	assert.T(t, err == nil, "got error? ", err)
+	task, _, err := job.VisitSourceSelect(srcPlan)
 	assert.T(t, err == nil)
 
 	tasks.Add(task.(TaskRunner))

--- a/exec/sqldriver.go
+++ b/exec/sqldriver.go
@@ -137,9 +137,7 @@ func (m *qlbConn) Begin() (driver.Tx, error) {
 	return nil, expr.ErrNotImplemented
 }
 
-// sql.Tx Interface implementation.
-//
-// Tx is a transaction.
+// sql.Tx Transaction Interface implementation.
 type qlbTx struct{}
 
 func (conn *qlbTx) Commit() error {

--- a/exec/task.go
+++ b/exec/task.go
@@ -136,7 +136,7 @@ msgLoop:
 		select {
 		case msg, ok = <-m.msgInCh:
 			if ok {
-				u.Debugf("sending to handler: %v %T  %+v", m.Type(), msg, msg)
+				//u.Debugf("sending to handler: %v %T  %+v", m.Type(), msg, msg)
 				m.Handler(ctx, msg)
 			} else {
 				u.Debugf("msg in closed shutting down: %s", m.TaskType)

--- a/exec/task.go
+++ b/exec/task.go
@@ -77,7 +77,7 @@ func (m *TaskBase) Children() Tasks { return nil }
 func (m *TaskBase) Setup(depth int) error {
 	m.depth = depth
 	m.setup = true
-	//u.Debugf("setup() %s %T in:%p  out:%p", m.TaskType, m, m.msgInCh, m.msgOutCh)
+	u.Debugf("setup() %s %T in:%p  out:%p", m.TaskType, m, m.msgInCh, m.msgOutCh)
 	return nil
 }
 func (m *TaskBase) Add(task TaskRunner) error    { return fmt.Errorf("This is not a list-type task %T", m) }

--- a/exec/task.go
+++ b/exec/task.go
@@ -77,7 +77,7 @@ func (m *TaskBase) Children() Tasks { return nil }
 func (m *TaskBase) Setup(depth int) error {
 	m.depth = depth
 	m.setup = true
-	u.Debugf("setup() %s %T in:%p  out:%p", m.TaskType, m, m.msgInCh, m.msgOutCh)
+	//u.Debugf("setup() %s %T in:%p  out:%p", m.TaskType, m, m.msgInCh, m.msgOutCh)
 	return nil
 }
 func (m *TaskBase) Add(task TaskRunner) error    { return fmt.Errorf("This is not a list-type task %T", m) }
@@ -136,10 +136,10 @@ msgLoop:
 		select {
 		case msg, ok = <-m.msgInCh:
 			if ok {
-				//u.Debugf("sending to handler: %v %T  %+v", m.Type(), msg, msg)
+				u.Debugf("sending to handler: %v %T  %+v", m.Type(), msg, msg)
 				m.Handler(ctx, msg)
 			} else {
-				//u.Debugf("msg in closed shutting down: %s", m.TaskType)
+				u.Debugf("msg in closed shutting down: %s", m.TaskType)
 				break msgLoop
 			}
 		case <-m.sigCh:

--- a/exec/task.go
+++ b/exec/task.go
@@ -139,7 +139,7 @@ msgLoop:
 				//u.Debugf("sending to handler: %v %T  %+v", m.Type(), msg, msg)
 				m.Handler(ctx, msg)
 			} else {
-				u.Debugf("msg in closed shutting down: %s", m.TaskType)
+				//u.Debugf("msg in closed shutting down: %s", m.TaskType)
 				break msgLoop
 			}
 		case <-m.sigCh:

--- a/exec/task_parallel.go
+++ b/exec/task_parallel.go
@@ -48,16 +48,16 @@ func (m *TaskParallel) Close() error {
 func (m *TaskParallel) Setup(depth int) error {
 	m.setup = true
 	if m.in != nil {
-		for i, task := range m.tasks {
+		for _, task := range m.tasks {
 			task.MessageInSet(m.in.MessageOut())
-			u.Infof("parallel task in: #%d task p:%p %s  %p", i, task, task.Type(), task.MessageIn())
+			//u.Infof("parallel task in: #%d task p:%p %s  %p", i, task, task.Type(), task.MessageIn())
 		}
 	}
 	for _, task := range m.tasks {
 		task.MessageOutSet(m.msgOutCh)
 	}
 	for i := 0; i < len(m.tasks); i++ {
-		u.Debugf("%d  Setup: %T", depth, m.tasks[i])
+		//u.Debugf("%d  Setup: %T", depth, m.tasks[i])
 		if err := m.tasks[i].Setup(depth + 1); err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func (m *TaskParallel) Run(ctx *expr.Context) error {
 				u.Errorf("%T.Run() errored %v", m.tasks[taskId], err)
 				// TODO:  what do we do with this error?   send to error channel?
 			}
-			u.Debugf("exiting taskId: %v %T", taskId, m.tasks[taskId])
+			//u.Debugf("exiting taskId: %v %T", taskId, m.tasks[taskId])
 			wg.Done()
 		}(i)
 	}

--- a/exec/task_parallel.go
+++ b/exec/task_parallel.go
@@ -57,7 +57,7 @@ func (m *TaskParallel) Setup(depth int) error {
 		task.MessageOutSet(m.msgOutCh)
 	}
 	for i := 0; i < len(m.tasks); i++ {
-		//u.Debugf("%d  Setup: %T", depth, m.tasks[i])
+		u.Debugf("%d  Setup: %T", depth, m.tasks[i])
 		if err := m.tasks[i].Setup(depth + 1); err != nil {
 			return err
 		}

--- a/exec/task_parallel.go
+++ b/exec/task_parallel.go
@@ -79,7 +79,7 @@ func (m *TaskParallel) Run(ctx *expr.Context) error {
 	defer ctx.Recover() // Our context can recover panics, save error msg
 	defer func() {
 		close(m.msgOutCh) // closing output channels is the signal to stop
-		u.Warnf("close TaskParallel: %v", m.Type())
+		u.Debugf("close TaskParallel: %v", m.Type())
 	}()
 
 	// Either of the SigQuit, or error channel will
@@ -104,7 +104,7 @@ func (m *TaskParallel) Run(ctx *expr.Context) error {
 				u.Errorf("%T.Run() errored %v", m.tasks[taskId], err)
 				// TODO:  what do we do with this error?   send to error channel?
 			}
-			u.Warnf("exiting taskId: %v %T", taskId, m.tasks[taskId])
+			u.Debugf("exiting taskId: %v %T", taskId, m.tasks[taskId])
 			wg.Done()
 		}(i)
 	}

--- a/exec/task_parallel.go
+++ b/exec/task_parallel.go
@@ -50,7 +50,7 @@ func (m *TaskParallel) Setup(depth int) error {
 	if m.in != nil {
 		for i, task := range m.tasks {
 			task.MessageInSet(m.in.MessageOut())
-			u.Infof("parallel task in: #%d  %s  %p", i, task.Type(), task.MessageIn())
+			u.Infof("parallel task in: #%d task p:%p %s  %p", i, task, task.Type(), task.MessageIn())
 		}
 	}
 	for _, task := range m.tasks {
@@ -79,7 +79,7 @@ func (m *TaskParallel) Run(ctx *expr.Context) error {
 	defer ctx.Recover() // Our context can recover panics, save error msg
 	defer func() {
 		close(m.msgOutCh) // closing output channels is the signal to stop
-		//u.Warnf("close TaskParallel: %v", m.Type())
+		u.Warnf("close TaskParallel: %v", m.Type())
 	}()
 
 	// Either of the SigQuit, or error channel will
@@ -104,7 +104,7 @@ func (m *TaskParallel) Run(ctx *expr.Context) error {
 				u.Errorf("%T.Run() errored %v", m.tasks[taskId], err)
 				// TODO:  what do we do with this error?   send to error channel?
 			}
-			//u.Warnf("exiting taskId: %v %T", taskId, tasks[taskId])
+			u.Warnf("exiting taskId: %v %T", taskId, m.tasks[taskId])
 			wg.Done()
 		}(i)
 	}

--- a/exec/task_sequential.go
+++ b/exec/task_sequential.go
@@ -43,7 +43,7 @@ func (m *TaskSequential) Setup(depth int) error {
 	m.depth = depth
 	m.setup = true
 	for i := 0; i < len(m.tasks); i++ {
-		u.Debugf("%d i:%d  Setup: %T p:%p", depth, i, m.tasks[i], m.tasks[i])
+		//u.Debugf("%d i:%d  Setup: %T p:%p", depth, i, m.tasks[i], m.tasks[i])
 		if err := m.tasks[i].Setup(depth + 1); err != nil {
 			return err
 		}

--- a/exec/task_sequential.go
+++ b/exec/task_sequential.go
@@ -43,7 +43,7 @@ func (m *TaskSequential) Setup(depth int) error {
 	m.depth = depth
 	m.setup = true
 	for i := 0; i < len(m.tasks); i++ {
-		//u.Debugf("%d i:%d  Setup: %T", depth, i, m.tasks[i])
+		u.Debugf("%d i:%d  Setup: %T p:%p", depth, i, m.tasks[i], m.tasks[i])
 		if err := m.tasks[i].Setup(depth + 1); err != nil {
 			return err
 		}
@@ -75,7 +75,7 @@ func (m *TaskSequential) Run(ctx *expr.Context) error {
 	defer ctx.Recover() // Our context can recover panics, save error msg
 	defer func() {
 		//close(m.msgOutCh) // closing output channels is the signal to stop
-		//u.Debugf("close TaskSequential: %v", m.Type())
+		u.Debugf("close TaskSequential: %v", m.Type())
 	}()
 
 	// Either of the SigQuit, or error channel will

--- a/exec/task_sequential.go
+++ b/exec/task_sequential.go
@@ -75,7 +75,7 @@ func (m *TaskSequential) Run(ctx *expr.Context) error {
 	defer ctx.Recover() // Our context can recover panics, save error msg
 	defer func() {
 		//close(m.msgOutCh) // closing output channels is the signal to stop
-		u.Debugf("close TaskSequential: %v", m.Type())
+		//u.Debugf("close TaskSequential: %v", m.Type())
 	}()
 
 	// Either of the SigQuit, or error channel will

--- a/expr/parse_sql.go
+++ b/expr/parse_sql.go
@@ -554,9 +554,9 @@ func (m *Sqlbridge) parseColumns(stmt *SqlSelect) error {
 				return err
 			}
 			col.Expr = tree.Root
-		case lex.TokenValue:
+		case lex.TokenValue, lex.TokenInteger:
 			// Value Literal
-			col = NewColumnFromToken(m.Cur())
+			col = NewColumnValue(m.Cur())
 			tree := NewTree(m.SqlTokenPager)
 			if err := m.parseNode(tree); err != nil {
 				u.Errorf("could not parse: %v", err)

--- a/expr/parse_sql.go
+++ b/expr/parse_sql.go
@@ -543,7 +543,7 @@ func (m *Sqlbridge) parseColumns(stmt *SqlSelect) error {
 
 		case lex.TokenIdentity:
 			if strings.HasPrefix(m.Cur().V, "@@") {
-				u.Warnf("@@ type sql %v", m.Cur())
+				u.Debugf("@@ type sql %v", m.Cur())
 				stmt.schemaqry = true
 			}
 

--- a/expr/parse_sql.go
+++ b/expr/parse_sql.go
@@ -543,7 +543,7 @@ func (m *Sqlbridge) parseColumns(stmt *SqlSelect) error {
 
 		case lex.TokenIdentity:
 			if strings.HasPrefix(m.Cur().V, "@@") {
-				u.Debugf("@@ type sql %v", m.Cur())
+				//u.Debugf("@@ type sql %v", m.Cur())
 				stmt.schemaqry = true
 			}
 

--- a/expr/parse_sql.go
+++ b/expr/parse_sql.go
@@ -542,7 +542,11 @@ func (m *Sqlbridge) parseColumns(stmt *SqlSelect) error {
 			//u.Debugf("next? %v", m.Cur())
 
 		case lex.TokenIdentity:
-			//u.Warnf("?? %v", m.Cur())
+			if strings.HasPrefix(m.Cur().V, "@@") {
+				u.Warnf("@@ type sql %v", m.Cur())
+				stmt.schemaqry = true
+			}
+
 			col = NewColumnFromToken(m.Cur())
 			tree := NewTree(m.SqlTokenPager)
 			if err := m.parseNode(tree); err != nil {

--- a/expr/parse_sql_test.go
+++ b/expr/parse_sql_test.go
@@ -25,6 +25,28 @@ func parseSqlTest(t *testing.T, sql string) {
 func TestSqlLexOnly(t *testing.T) {
 
 	parseSqlTest(t, `
+		select  @@session.auto_increment_increment as auto_increment_increment, 
+					@@character_set_client as character_set_client, 
+					@@character_set_connection as character_set_connection, 
+					@@character_set_results as character_set_results, 
+					@@character_set_server as character_set_server, 
+					@@init_connect as init_connect, 
+					@@interactive_timeout as interactive_timeout, 
+					@@license as license, 
+					@@lower_case_table_names as lower_case_table_names,
+					@@max_allowed_packet as max_allowed_packet, 
+					@@net_buffer_length as net_buffer_length, 
+					@@net_write_timeout as net_write_timeout, 
+					@@query_cache_size as query_cache_size, 
+					@@query_cache_type as query_cache_type, 
+					@@sql_mode as sql_mode, 
+					@@system_time_zone as system_time_zone, 
+					@@time_zone as time_zone, 
+					@@tx_isolation as tx_isolation, 
+					@@wait_timeout as wait_timeout
+	`)
+
+	parseSqlTest(t, `
 		SELECT a.language, a.template, Count(*) AS count
 		FROM 
 			(Select Distinct language, template FROM content) AS a

--- a/expr/parse_sql_test.go
+++ b/expr/parse_sql_test.go
@@ -67,6 +67,7 @@ func TestSqlLexOnly(t *testing.T) {
 	parseSqlTest(t, `DESCRIBE mytable`)
 	parseSqlTest(t, `show tables`)
 
+	parseSqlTest(t, `select 3, director from movies`)
 	parseSqlTest(t, `select director, year from movies where year BETWEEN 2000 AND 2010;`)
 	parseSqlTest(t, `select director, year from movies where director like 'Quentin'`)
 	parseSqlTest(t, `select director, year from movies where !exists(user_id) OR toint(not_a_field) > 21`)

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -987,7 +987,7 @@ func (m *SqlSource) Rewrite(parentStmt *SqlSelect) *SqlSelect {
 	m.Source = sql2
 	//u.Infof("going to unaliase: #cols=%v %#v", len(sql2.Columns), sql2.Columns)
 	m.cols = sql2.UnAliasedColumns()
-	//u.Infof("after aliasing: %#v", m.cols)
+	u.Infof("after aliasing: %#v sql2=%s", m.cols, sql2.String())
 	return sql2
 }
 

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -41,7 +41,7 @@ func init() {
 //  Select, Insert, Delete etc
 type SqlStatement interface {
 	Node
-	Accept(visitor Visitor) (Task, error)
+	Accept(visitor Visitor) (Task, VisitStatus, error)
 	Keyword() lex.TokenType
 }
 
@@ -49,7 +49,7 @@ type SqlStatement interface {
 //   Join, SubSelect, From
 type SqlSubStatement interface {
 	Node
-	Accept(visitor SubVisitor) (Task, error)
+	Accept(visitor SubVisitor) (Task, VisitStatus, error)
 	Keyword() lex.TokenType
 }
 
@@ -486,7 +486,7 @@ func (m *Column) LeftRight() (string, string, bool) {
 	return m.left, m.right, m.left != ""
 }
 
-func (m *PreparedStatement) Accept(visitor Visitor) (Task, error) {
+func (m *PreparedStatement) Accept(visitor Visitor) (Task, VisitStatus, error) {
 	return visitor.VisitPreparedStmt(m)
 }
 func (m *PreparedStatement) Keyword() lex.TokenType { return lex.TokenPrepare }
@@ -500,12 +500,12 @@ func (m *PreparedStatement) FingerPrint(r rune) string {
 	return fmt.Sprintf("PREPARE %s FROM %s", m.Alias, m.Statement.FingerPrint(r))
 }
 
-func (m *SqlSelect) Accept(visitor Visitor) (Task, error) { return visitor.VisitSelect(m) }
-func (m *SqlSelect) Keyword() lex.TokenType               { return lex.TokenSelect }
-func (m *SqlSelect) Check() error                         { return nil }
-func (m *SqlSelect) NodeType() NodeType                   { return SqlSelectNodeType }
-func (m *SqlSelect) Type() reflect.Value                  { return nilRv }
-func (m *SqlSelect) SystemQry() bool                      { return len(m.From) == 0 && m.schemaqry }
+func (m *SqlSelect) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitSelect(m) }
+func (m *SqlSelect) Keyword() lex.TokenType                            { return lex.TokenSelect }
+func (m *SqlSelect) Check() error                                      { return nil }
+func (m *SqlSelect) NodeType() NodeType                                { return SqlSelectNodeType }
+func (m *SqlSelect) Type() reflect.Value                               { return nilRv }
+func (m *SqlSelect) SystemQry() bool                                   { return len(m.From) == 0 && m.schemaqry }
 func (m *SqlSelect) String() string {
 	buf := bytes.Buffer{}
 	m.writeBuf(0, &buf)
@@ -756,11 +756,13 @@ func (m *SqlSelect) SysVariable() string {
 	return ""
 }
 
-func (m *SqlSource) Accept(visitor SubVisitor) (Task, error) { return visitor.VisitSubSelect(m) }
-func (m *SqlSource) Keyword() lex.TokenType                  { return m.Op }
-func (m *SqlSource) Check() error                            { return nil }
-func (m *SqlSource) Type() reflect.Value                     { return nilRv }
-func (m *SqlSource) NodeType() NodeType                      { return SqlSourceNodeType }
+func (m *SqlSource) Accept(visitor SubVisitor) (Task, VisitStatus, error) {
+	return visitor.VisitSubSelect(m)
+}
+func (m *SqlSource) Keyword() lex.TokenType { return m.Op }
+func (m *SqlSource) Check() error           { return nil }
+func (m *SqlSource) Type() reflect.Value    { return nilRv }
+func (m *SqlSource) NodeType() NodeType     { return SqlSourceNodeType }
 func (m *SqlSource) SourceName() string {
 	if m.SubQuery != nil {
 		if len(m.SubQuery.From) == 1 {
@@ -1435,11 +1437,11 @@ func (m *Join) NodeType() NodeType                             { return SqlJoinN
 func (m *Join) StringAST() string                              { return m.String() }
 func (m *Join) String() string                                 { return fmt.Sprintf("%s", m.Table) }
 */
-func (m *SqlInsert) Keyword() lex.TokenType               { return m.kw }
-func (m *SqlInsert) Check() error                         { return nil }
-func (m *SqlInsert) Type() reflect.Value                  { return nilRv }
-func (m *SqlInsert) NodeType() NodeType                   { return SqlInsertNodeType }
-func (m *SqlInsert) Accept(visitor Visitor) (Task, error) { return visitor.VisitInsert(m) }
+func (m *SqlInsert) Keyword() lex.TokenType                            { return m.kw }
+func (m *SqlInsert) Check() error                                      { return nil }
+func (m *SqlInsert) Type() reflect.Value                               { return nilRv }
+func (m *SqlInsert) NodeType() NodeType                                { return SqlInsertNodeType }
+func (m *SqlInsert) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitInsert(m) }
 func (m *SqlInsert) String() string {
 	buf := bytes.Buffer{}
 	buf.WriteString(fmt.Sprintf("INSERT INTO %s (", m.Table))
@@ -1495,20 +1497,20 @@ func (m *SqlInsert) ColumnNames() []string {
 	return cols
 }
 
-func (m *SqlUpsert) Keyword() lex.TokenType               { return lex.TokenUpsert }
-func (m *SqlUpsert) Check() error                         { return nil }
-func (m *SqlUpsert) Type() reflect.Value                  { return nilRv }
-func (m *SqlUpsert) NodeType() NodeType                   { return SqlUpsertNodeType }
-func (m *SqlUpsert) String() string                       { return fmt.Sprintf("%s ", m.Keyword()) }
-func (m *SqlUpsert) FingerPrint(r rune) string            { return m.String() }
-func (m *SqlUpsert) Accept(visitor Visitor) (Task, error) { return visitor.VisitUpsert(m) }
-func (m *SqlUpsert) SqlSelect() *SqlSelect                { return sqlSelectFromWhere(m.Table, m.Where) }
+func (m *SqlUpsert) Keyword() lex.TokenType                            { return lex.TokenUpsert }
+func (m *SqlUpsert) Check() error                                      { return nil }
+func (m *SqlUpsert) Type() reflect.Value                               { return nilRv }
+func (m *SqlUpsert) NodeType() NodeType                                { return SqlUpsertNodeType }
+func (m *SqlUpsert) String() string                                    { return fmt.Sprintf("%s ", m.Keyword()) }
+func (m *SqlUpsert) FingerPrint(r rune) string                         { return m.String() }
+func (m *SqlUpsert) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitUpsert(m) }
+func (m *SqlUpsert) SqlSelect() *SqlSelect                             { return sqlSelectFromWhere(m.Table, m.Where) }
 
-func (m *SqlUpdate) Keyword() lex.TokenType               { return lex.TokenUpdate }
-func (m *SqlUpdate) Check() error                         { return nil }
-func (m *SqlUpdate) Type() reflect.Value                  { return nilRv }
-func (m *SqlUpdate) NodeType() NodeType                   { return SqlUpdateNodeType }
-func (m *SqlUpdate) Accept(visitor Visitor) (Task, error) { return visitor.VisitUpdate(m) }
+func (m *SqlUpdate) Keyword() lex.TokenType                            { return lex.TokenUpdate }
+func (m *SqlUpdate) Check() error                                      { return nil }
+func (m *SqlUpdate) Type() reflect.Value                               { return nilRv }
+func (m *SqlUpdate) NodeType() NodeType                                { return SqlUpdateNodeType }
+func (m *SqlUpdate) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitUpdate(m) }
 func (m *SqlUpdate) String() string {
 	buf := bytes.Buffer{}
 	buf.WriteString(fmt.Sprintf("UPDATE %s SET", m.Table))
@@ -1549,30 +1551,32 @@ func sqlSelectFromWhere(from string, where Node) *SqlSelect {
 	return req
 }
 
-func (m *SqlDelete) Keyword() lex.TokenType               { return lex.TokenDelete }
-func (m *SqlDelete) Check() error                         { return nil }
-func (m *SqlDelete) Type() reflect.Value                  { return nilRv }
-func (m *SqlDelete) NodeType() NodeType                   { return SqlDeleteNodeType }
-func (m *SqlDelete) String() string                       { return fmt.Sprintf("%s ", m.Keyword()) }
-func (m *SqlDelete) FingerPrint(r rune) string            { return m.String() }
-func (m *SqlDelete) Accept(visitor Visitor) (Task, error) { return visitor.VisitDelete(m) }
-func (m *SqlDelete) SqlSelect() *SqlSelect                { return sqlSelectFromWhere(m.Table, m.Where) }
+func (m *SqlDelete) Keyword() lex.TokenType                            { return lex.TokenDelete }
+func (m *SqlDelete) Check() error                                      { return nil }
+func (m *SqlDelete) Type() reflect.Value                               { return nilRv }
+func (m *SqlDelete) NodeType() NodeType                                { return SqlDeleteNodeType }
+func (m *SqlDelete) String() string                                    { return fmt.Sprintf("%s ", m.Keyword()) }
+func (m *SqlDelete) FingerPrint(r rune) string                         { return m.String() }
+func (m *SqlDelete) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitDelete(m) }
+func (m *SqlDelete) SqlSelect() *SqlSelect                             { return sqlSelectFromWhere(m.Table, m.Where) }
 
-func (m *SqlDescribe) Keyword() lex.TokenType               { return lex.TokenDescribe }
-func (m *SqlDescribe) Check() error                         { return nil }
-func (m *SqlDescribe) Type() reflect.Value                  { return nilRv }
-func (m *SqlDescribe) NodeType() NodeType                   { return SqlDescribeNodeType }
-func (m *SqlDescribe) String() string                       { return fmt.Sprintf("%s ", m.Keyword()) }
-func (m *SqlDescribe) FingerPrint(r rune) string            { return m.String() }
-func (m *SqlDescribe) Accept(visitor Visitor) (Task, error) { return visitor.VisitDescribe(m) }
+func (m *SqlDescribe) Keyword() lex.TokenType    { return lex.TokenDescribe }
+func (m *SqlDescribe) Check() error              { return nil }
+func (m *SqlDescribe) Type() reflect.Value       { return nilRv }
+func (m *SqlDescribe) NodeType() NodeType        { return SqlDescribeNodeType }
+func (m *SqlDescribe) String() string            { return fmt.Sprintf("%s ", m.Keyword()) }
+func (m *SqlDescribe) FingerPrint(r rune) string { return m.String() }
+func (m *SqlDescribe) Accept(visitor Visitor) (Task, VisitStatus, error) {
+	return visitor.VisitDescribe(m)
+}
 
-func (m *SqlShow) Keyword() lex.TokenType               { return lex.TokenShow }
-func (m *SqlShow) Check() error                         { return nil }
-func (m *SqlShow) Type() reflect.Value                  { return nilRv }
-func (m *SqlShow) NodeType() NodeType                   { return SqlShowNodeType }
-func (m *SqlShow) String() string                       { return fmt.Sprintf("%s ", m.Keyword()) }
-func (m *SqlShow) FingerPrint(r rune) string            { return m.String() }
-func (m *SqlShow) Accept(visitor Visitor) (Task, error) { return visitor.VisitShow(m) }
+func (m *SqlShow) Keyword() lex.TokenType                            { return lex.TokenShow }
+func (m *SqlShow) Check() error                                      { return nil }
+func (m *SqlShow) Type() reflect.Value                               { return nilRv }
+func (m *SqlShow) NodeType() NodeType                                { return SqlShowNodeType }
+func (m *SqlShow) String() string                                    { return fmt.Sprintf("%s ", m.Keyword()) }
+func (m *SqlShow) FingerPrint(r rune) string                         { return m.String() }
+func (m *SqlShow) Accept(visitor Visitor) (Task, VisitStatus, error) { return visitor.VisitShow(m) }
 
 func (m *CommandColumn) FingerPrint(r rune) string { return m.String() }
 func (m *CommandColumn) String() string {
@@ -1600,10 +1604,12 @@ func (m *CommandColumns) String() string {
 	return strings.Join(s, ", ")
 }
 
-func (m *SqlCommand) Keyword() lex.TokenType               { return m.kw }
-func (m *SqlCommand) Check() error                         { return nil }
-func (m *SqlCommand) Type() reflect.Value                  { return nilRv }
-func (m *SqlCommand) NodeType() NodeType                   { return SqlCommandNodeType }
-func (m *SqlCommand) FingerPrint(r rune) string            { return m.String() }
-func (m *SqlCommand) String() string                       { return fmt.Sprintf("%s %s", m.Keyword(), m.Columns.String()) }
-func (m *SqlCommand) Accept(visitor Visitor) (Task, error) { return visitor.VisitCommand(m) }
+func (m *SqlCommand) Keyword() lex.TokenType    { return m.kw }
+func (m *SqlCommand) Check() error              { return nil }
+func (m *SqlCommand) Type() reflect.Value       { return nilRv }
+func (m *SqlCommand) NodeType() NodeType        { return SqlCommandNodeType }
+func (m *SqlCommand) FingerPrint(r rune) string { return m.String() }
+func (m *SqlCommand) String() string            { return fmt.Sprintf("%s %s", m.Keyword(), m.Columns.String()) }
+func (m *SqlCommand) Accept(visitor Visitor) (Task, VisitStatus, error) {
+	return visitor.VisitCommand(m)
+}

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -226,7 +226,11 @@ func NewProjection() *Projection {
 	return &Projection{Columns: make(ResultColumns, 0)}
 }
 func NewResultColumn(as string, ordinal int, col *Column, valtype value.ValueType) *ResultColumn {
-	return &ResultColumn{Name: as, As: as, ColPos: ordinal, Col: col, Type: valtype}
+	rc := ResultColumn{Name: as, As: as, ColPos: ordinal, Col: col, Type: valtype}
+	if col != nil {
+		rc.Name = col.SourceField
+	}
+	return &rc
 }
 func NewSqlSelect() *SqlSelect {
 	req := &SqlSelect{}

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -77,7 +77,8 @@ type (
 		Alias     string       // Non-Standard sql, alias/name of sql another way of expression Prepared Statement
 		With      u.JsonHelper // Non-Standard SQL for properties/config info, similar to Cassandra with, purse json
 		proj      *Projection  // Projected fields
-		finalized bool
+		finalized bool         // have we already finalized, ie formalized left/right aliases
+		schemaqry bool         // is this a schema qry?  ie select @@max_packet etc
 	}
 	// Source is a table name, sub-query, or join as used in
 	// SELECT <columns> FROM <SQLSOURCE>
@@ -194,7 +195,8 @@ type (
 		As     string          // aliased
 		Type   value.ValueType // Data Type
 	}
-	// Projection is just the ResultColumns for a result-set
+	// Projection describes the results to expect from sql statement
+	// ie the ResultColumns for a result-set
 	Projection struct {
 		Distinct bool
 		Columns  ResultColumns
@@ -497,6 +499,7 @@ func (m *SqlSelect) Keyword() lex.TokenType               { return lex.TokenSele
 func (m *SqlSelect) Check() error                         { return nil }
 func (m *SqlSelect) NodeType() NodeType                   { return SqlSelectNodeType }
 func (m *SqlSelect) Type() reflect.Value                  { return nilRv }
+func (m *SqlSelect) SystemQry() bool                      { return len(m.From) == 0 && m.schemaqry }
 func (m *SqlSelect) String() string {
 	buf := bytes.Buffer{}
 	m.writeBuf(0, &buf)

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -285,7 +285,9 @@ func NewColumn(col string) *Column {
 func (m *Projection) AddColumnShort(name string, vt value.ValueType) {
 	m.Columns = append(m.Columns, NewResultColumn(name, len(m.Columns), nil, vt))
 }
-
+func (m *Projection) AddColumn(col *Column, vt value.ValueType) {
+	m.Columns = append(m.Columns, NewResultColumn(col.As, len(m.Columns), col, vt))
+}
 func (m *Columns) FingerPrint(r rune) string {
 	colCt := len(*m)
 	if colCt == 1 {

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -114,6 +114,7 @@ type (
 		Source *SqlSelect    // IN (SELECT a,b,c from z)
 		Expr   Node          // x = y
 	}
+	// SQL Insert Statement
 	SqlInsert struct {
 		kw      lex.TokenType    // Insert, Replace
 		Table   string           // table name
@@ -121,6 +122,7 @@ type (
 		Rows    [][]*ValueColumn // Values to insert
 		Select  *SqlSelect       //
 	}
+	// SQL (non-standard) Upsert Statement
 	SqlUpsert struct {
 		Columns Columns
 		Rows    [][]*ValueColumn
@@ -128,30 +130,36 @@ type (
 		Where   Node
 		Table   string
 	}
+	// SQL Update Statement
 	SqlUpdate struct {
 		Values map[string]*ValueColumn
 		Where  Node
 		Table  string
 	}
+	// SQL Delete Statement
 	SqlDelete struct {
 		Table string
 		Where Node
 		Limit int
 	}
+	// SQL SHOW Statement
 	SqlShow struct {
 		Raw      string
 		Identity string
 		From     string
 		Full     bool
 	}
+	// SQL Describe statement
 	SqlDescribe struct {
 		Identity string
 		Tok      lex.Token // Explain, Describe, Desc
 		Stmt     SqlStatement
 	}
+	// SQL INTO statement   (select x from y INTO z)
 	SqlInto struct {
 		Table string
 	}
+	// Sql Command is admin command such as "SET"
 	SqlCommand struct {
 		kw       lex.TokenType // SET
 		Columns  CommandColumns
@@ -184,8 +192,9 @@ type (
 		Value value.Value
 		Expr  Node
 	}
+	// List of ResultColumns used in projections
 	ResultColumns []*ResultColumn
-	// Result Column
+	// Result Column used in projection
 	ResultColumn struct {
 		Final  bool            // Is this part of final projection (ie, response)
 		Name   string          // Original path/name for query field
@@ -206,7 +215,8 @@ type (
 	//     SET @@local.sort_buffer_size=10000;
 	//     USE myschema;
 	CommandColumns []*CommandColumn
-	CommandColumn  struct {
+	// Command column is single column such as "autocommit"
+	CommandColumn struct {
 		Expr Node   // column expression
 		Name string // Original path/name for command field
 	}
@@ -431,6 +441,9 @@ func (m *Column) CountStar() bool {
 		return strings.ToLower(fn.Name) == "count" && fn.Args[0].String() == `*`
 	}
 	return false
+}
+func (m *Column) InFinalProjection() bool {
+	return m.ParentIndex >= 0
 }
 
 // Create a new copy of this column for rewrite purposes re-alias

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -279,6 +279,7 @@ func NewColumn(col string) *Column {
 	return &Column{
 		As:          col,
 		SourceField: col,
+		Expr:        &IdentityNode{Text: col},
 	}
 }
 
@@ -889,7 +890,7 @@ func (m *SqlSource) BuildColIndex(colNames []string) error {
 		for colIdx, colName := range colNames {
 			//u.Debugf("col.Key():%v  sourceField:%v  colName:%v", col.Key(), col.SourceField, colName)
 			if colName == col.Key() || col.SourceField == colName { //&&
-				u.Debugf("build col:  idx=%d  key=%-15q as=%-15q col=%-15s sourcidx:%d", len(m.colIndex), col.Key(), col.As, col.String(), colIdx)
+				//u.Debugf("build col:  idx=%d  key=%-15q as=%-15q col=%-15s sourcidx:%d", len(m.colIndex), col.Key(), col.As, col.String(), colIdx)
 				m.colIndex[col.Key()] = colIdx
 				col.SourceIndex = colIdx
 				found = true
@@ -909,7 +910,7 @@ func (m *SqlSource) BuildColIndex(colNames []string) error {
 //  @parentStmt = the parent statement that this a partial source to
 func (m *SqlSource) Rewrite(parentStmt *SqlSelect) *SqlSelect {
 
-	u.Debugf("Rewrite %s", m.String())
+	//u.Debugf("Rewrite %s", m.String())
 	if m.Source != nil {
 		return m.Source
 	}
@@ -948,7 +949,7 @@ func (m *SqlSource) Rewrite(parentStmt *SqlSelect) *SqlSelect {
 				newCol.SourceIndex = len(newCols)
 				newCol.Index = len(newCols)
 				newCols = append(newCols, newCol)
-				u.Debugf("source rewrite: %s idx:%d sidx:%d pidx:%d", newCol.As, newCol.Index, newCol.SourceIndex, newCol.ParentIndex)
+				//u.Debugf("source rewrite: %s idx:%d sidx:%d pidx:%d", newCol.As, newCol.Index, newCol.SourceIndex, newCol.ParentIndex)
 
 			} else {
 				// not used in this source
@@ -984,10 +985,14 @@ func (m *SqlSource) Rewrite(parentStmt *SqlSelect) *SqlSelect {
 			//u.Debugf("from: %q     joinP: %p  join: %q", from.String(), from.JoinExpr, from.JoinExpr.String())
 			joinNodesForFrom(parentStmt, m, from.JoinExpr, 0)
 			//u.Debugf("P %p pre:%v  post:%v  for:%q", m, preNodeCt, len(m.joinNodes), m.String())
+
 		} else {
 			//u.Debugf("nil join? %v", from.String())
 		}
 	}
+	// for _, jn := range m.joinNodes {
+	// 	u.Debugf("jh %s", jn.String())
+	// }
 	//u.Debugf("cols len: %v", len(sql2.Columns))
 	if parentStmt.Where != nil {
 		node, cols := rewriteWhere(parentStmt, m, parentStmt.Where.Expr, make(Columns, 0))

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -187,9 +187,9 @@ type (
 	ResultColumns []*ResultColumn
 	// Result Column
 	ResultColumn struct {
-		//Expr   Node            // If expression, is here
+		Final  bool            // Is this part of final projection (ie, response)
 		Name   string          // Original path/name for query field
-		ColPos int             // Ordinal position in sql statement
+		ColPos int             // Ordinal position in sql (or partial sql) statement
 		Col    *Column         // the original sql column
 		Star   bool            // Was this a select * ??
 		As     string          // aliased

--- a/expr/sql_test.go
+++ b/expr/sql_test.go
@@ -160,13 +160,13 @@ func TestSqlRewrite(t *testing.T) {
 	assert.Tf(t, rw1 != nil, "should not be nil:")
 	assert.Tf(t, len(rw1.Columns) == 3, "has 3 cols: %v", rw1.Columns.String())
 	//u.Infof("SQL?: '%v'", rw1.String())
-	assert.Tf(t, rw1.String() == "SELECT u.name, u.email, user_id FROM users", "%v", rw1.String())
+	assert.Tf(t, rw1.String() == "SELECT name, email, user_id FROM users", "%v", rw1.String())
 
 	rw1 = sql.From[1].Rewrite(sql)
 	assert.Tf(t, rw1 != nil, "should not be nil:")
 	assert.Tf(t, len(rw1.Columns) == 3, "has 3 cols: %v", rw1.Columns.String())
 	//u.Infof("SQL?: '%v'", rw1.String())
-	assert.Tf(t, rw1.String() == "SELECT o.item_id, o.price, user_id FROM orders", "%v", rw1.String())
+	assert.Tf(t, rw1.String() == "SELECT item_id, price, user_id FROM orders", "%v", rw1.String())
 
 	// Do we change?
 	//assert.Equal(t, sql.Columns.FieldNames(), []string{"user_id", "email", "item_id", "price"})
@@ -181,7 +181,7 @@ func TestSqlRewrite(t *testing.T) {
 	assert.Tf(t, rw1 != nil, "should not be nil:")
 	assert.Tf(t, len(rw1.Columns) == 2, "has 2 cols: %v", rw1.Columns.String())
 	//u.Infof("SQL?: '%v'", rw1.String())
-	assert.Tf(t, rw1.String() == "SELECT u.name, u.email FROM users", "%v", rw1.String())
+	assert.Tf(t, rw1.String() == "SELECT name, email FROM users", "%v", rw1.String())
 	jn := sql.From[0].JoinNodes()
 	assert.Tf(t, len(jn) == 1, "%v", jn)
 	assert.Tf(t, jn[0].String() == "name", "wanted 1 node %v", jn[0].String())
@@ -204,7 +204,7 @@ func TestSqlRewrite(t *testing.T) {
 	sql.Rewrite()
 	selu := sql.From[0].Source
 	assert.Tf(t, len(selu.Columns) == 3, "user 3 cols: %v", selu.Columns.String())
-	assert.Tf(t, selu.String() == "SELECT u.name, u.email, author FROM users", "%v", selu.String())
+	assert.Tf(t, selu.String() == "SELECT name, email, author FROM users", "%v", selu.String())
 	jn = sql.From[0].JoinNodes()
 	assert.Tf(t, len(jn) == 1, "wanted 1 node but got fromP: %p   %v", sql.From[0], jn)
 	assert.Tf(t, jn[0].String() == "tolower(author)", "wanted 1 node %v", jn[0].String())
@@ -223,7 +223,7 @@ func TestSqlRewrite(t *testing.T) {
 	assert.Tf(t, rw1 != nil, "should not be nil:")
 	assert.Tf(t, len(rw1.Columns) == 3, "has 3 cols: %v", rw1.Columns.String())
 	//u.Infof("SQL?: '%v'", rw1.String())
-	assert.Tf(t, rw1.String() == "SELECT u.name, u.email, alias FROM users", "%v", rw1.String())
+	assert.Tf(t, rw1.String() == "SELECT name, email, alias FROM users", "%v", rw1.String())
 	jn = sql.From[0].JoinNodes()
 	assert.Tf(t, len(jn) == 2, "wanted 2 join nodes but %v", len(jn))
 	assert.Tf(t, jn[0].String() == "name", `want "name" %v`, jn[0].String())
@@ -255,11 +255,11 @@ func TestSqlRewrite(t *testing.T) {
 	assert.Tf(t, rw0 != nil, "should not be nil:")
 	assert.Tf(t, len(rw0.Columns) == 3, "has 3 cols: %v", rw0.String())
 	assert.Tf(t, len(sql.From[0].Source.Columns) == 3, "has 3 cols? %s", sql.From[0].Source)
-	assert.Tf(t, rw0.String() == "SELECT a.title, author, email FROM article WHERE email != NULL", "Wrong SQL 0: %v", rw0.String())
+	assert.Tf(t, rw0.String() == "SELECT title, author, email FROM article WHERE email != NULL", "Wrong SQL 0: %v", rw0.String())
 	assert.Tf(t, rw1 != nil, "should not be nil:")
 	assert.Tf(t, len(rw1.Columns) == 3, "has 3 cols: %v", rw1.Columns.String())
 	assert.Tf(t, len(sql.From[1].Source.Columns) == 3, "has 3 cols? %s", sql.From[1].Source)
-	assert.Tf(t, rw1.String() == "SELECT p.actor, p.repository.name, follow_ct FROM github_push WHERE follow_ct > 20", "Wrong SQL 1: %v", rw1.String())
+	assert.Tf(t, rw1.String() == "SELECT actor, repository.name, follow_ct FROM github_push WHERE follow_ct > 20", "Wrong SQL 1: %v", rw1.String())
 
 	// Original should still be the same
 	parts := strings.Split(sql.String(), "\n")

--- a/expr/visitor.go
+++ b/expr/visitor.go
@@ -5,6 +5,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+var _ = u.EMPTY
+
 type VisitStatus int
 
 const (

--- a/expr/visitor.go
+++ b/expr/visitor.go
@@ -9,7 +9,7 @@ type VisitStatus int
 
 const (
 	VisitUnknown  VisitStatus = 0 // not used
-	VisitError    VisitStatus = 0 // not used
+	VisitError    VisitStatus = 1 // error
 	VisitFinal    VisitStatus = 2 // final, no more building needed
 	VisitContinue VisitStatus = 3 // continue visit
 )
@@ -60,8 +60,7 @@ type Visitor interface {
 	VisitCommand(stmt *SqlCommand) (Task, VisitStatus, error)
 }
 
-// Interface for sub-select Tasks of the Select Statement, joins, sub-selects
-type SubVisitor interface {
-	VisitSubSelect(stmt *SqlSource) (Task, VisitStatus, error)
-	//VisitJoin(stmt *SqlSource) (Task, error)
+// Interface for sub-select Tasks of the Select Statement
+type SourceVisitor interface {
+	VisitSourceSelect(stmt *SqlSource) (Task, VisitStatus, error)
 }

--- a/expr/visitor.go
+++ b/expr/visitor.go
@@ -5,6 +5,15 @@ import (
 	"golang.org/x/net/context"
 )
 
+type VisitStatus int
+
+const (
+	VisitUnknown  VisitStatus = 0 // not used
+	VisitError    VisitStatus = 0 // not used
+	VisitFinal    VisitStatus = 2 // final, no more building needed
+	VisitContinue VisitStatus = 3 // continue visit
+)
+
 // Context for Plan/Execution
 type Context struct {
 	context.Context
@@ -40,19 +49,19 @@ type Task interface {
 //   in our case: planner(s), job builder, execution engine
 //
 type Visitor interface {
-	VisitPreparedStmt(stmt *PreparedStatement) (Task, error)
-	VisitSelect(stmt *SqlSelect) (Task, error)
-	VisitInsert(stmt *SqlInsert) (Task, error)
-	VisitUpsert(stmt *SqlUpsert) (Task, error)
-	VisitUpdate(stmt *SqlUpdate) (Task, error)
-	VisitDelete(stmt *SqlDelete) (Task, error)
-	VisitShow(stmt *SqlShow) (Task, error)
-	VisitDescribe(stmt *SqlDescribe) (Task, error)
-	VisitCommand(stmt *SqlCommand) (Task, error)
+	VisitPreparedStmt(stmt *PreparedStatement) (Task, VisitStatus, error)
+	VisitSelect(stmt *SqlSelect) (Task, VisitStatus, error)
+	VisitInsert(stmt *SqlInsert) (Task, VisitStatus, error)
+	VisitUpsert(stmt *SqlUpsert) (Task, VisitStatus, error)
+	VisitUpdate(stmt *SqlUpdate) (Task, VisitStatus, error)
+	VisitDelete(stmt *SqlDelete) (Task, VisitStatus, error)
+	VisitShow(stmt *SqlShow) (Task, VisitStatus, error)
+	VisitDescribe(stmt *SqlDescribe) (Task, VisitStatus, error)
+	VisitCommand(stmt *SqlCommand) (Task, VisitStatus, error)
 }
 
 // Interface for sub-select Tasks of the Select Statement, joins, sub-selects
 type SubVisitor interface {
-	VisitSubSelect(stmt *SqlSource) (Task, error)
+	VisitSubSelect(stmt *SqlSource) (Task, VisitStatus, error)
 	//VisitJoin(stmt *SqlSource) (Task, error)
 }

--- a/expr/visitor.go
+++ b/expr/visitor.go
@@ -53,6 +53,6 @@ type Visitor interface {
 
 // Interface for sub-select Tasks of the Select Statement, joins, sub-selects
 type SubVisitor interface {
-	VisitSubselect(stmt *SqlSource) (Task, error)
-	VisitJoin(stmt *SqlSource) (Task, error)
+	VisitSubSelect(stmt *SqlSource) (Task, error)
+	//VisitJoin(stmt *SqlSource) (Task, error)
 }

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -1461,7 +1461,7 @@ func LexSelectClause(l *Lexer) StateFn {
 		l.ConsumeWord(word)
 		l.Emit(TokenIdentity)
 		//u.Debugf("Found Sql Variable:  @@%v", word)
-		return nil
+		return LexSelectList
 	default:
 		//u.Debugf("not found %v", first)
 	}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -31,6 +31,10 @@ type (
 		*expr.SqlSelect
 		Sources []*SourcePlan
 	}
+	InsertPlan struct {
+		*expr.SqlInsert
+		Sources []*SourcePlan
+	}
 )
 
 // A PlanTask is a part of a Plan, each task may have children

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -76,8 +76,8 @@ func NewPlanner(schema string, stmt expr.SqlStatement, sys datasource.RuntimeSch
 	case *expr.SqlSelect:
 		plan.where = sql.Where
 	}
-	task, status, err := stmt.Accept(plan)
-	u.Debugf("task:  %T  %#v", task, task)
+	_, status, err := stmt.Accept(plan)
+	//u.Debugf("task:  %T  %#v", task, task)
 	if err != nil {
 		return nil, status, err
 	}
@@ -86,7 +86,7 @@ func NewPlanner(schema string, stmt expr.SqlStatement, sys datasource.RuntimeSch
 }
 
 func (m *SourcePlan) load(conf *datasource.RuntimeSchema) error {
-	u.Debugf("SourcePlan.load()")
+	//u.Debugf("SourcePlan.load()")
 	fromName := strings.ToLower(m.SqlSource.SourceName())
 	m.DataSource = conf.Sources.Get(fromName)
 	if m.DataSource == nil {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -35,7 +35,7 @@ type Planner struct {
 	tasks  []PlanTask
 }
 
-func NewPlanner(schema string, stmt expr.SqlStatement, sys datasource.RuntimeSchema) (*Planner, error) {
+func NewPlanner(schema string, stmt expr.SqlStatement, sys datasource.RuntimeSchema) (*Planner, expr.VisitStatus, error) {
 
 	plan := &Planner{
 		schema: schema,
@@ -45,55 +45,55 @@ func NewPlanner(schema string, stmt expr.SqlStatement, sys datasource.RuntimeSch
 	case *expr.SqlSelect:
 		plan.where = sql.Where
 	}
-	task, err := stmt.Accept(plan)
+	task, status, err := stmt.Accept(plan)
 	u.Debugf("task:  %T  %#v", task, task)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 
-	return plan, nil
+	return plan, status, nil
 }
 
-func (m *Planner) VisitSelect(stmt *expr.SqlSelect) (expr.Task, error) {
+func (m *Planner) VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitSource %+v", stmt)
-	return nil, nil
+	return nil, expr.VisitError, nil
 }
 
-func (m *Planner) VisitInsert(stmt *expr.SqlInsert) (expr.Task, error) {
+func (m *Planner) VisitInsert(stmt *expr.SqlInsert) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitInsert %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitDelete(stmt *expr.SqlDelete) (expr.Task, error) {
+func (m *Planner) VisitDelete(stmt *expr.SqlDelete) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitDelete %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, error) {
+func (m *Planner) VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitUpdate %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, error) {
+func (m *Planner) VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitUpdate %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitShow(stmt *expr.SqlShow) (expr.Task, error) {
+func (m *Planner) VisitShow(stmt *expr.SqlShow) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitShow %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, error) {
+func (m *Planner) VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitDescribe %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
 
-func (m *Planner) VisitPreparedStmt(stmt *expr.PreparedStatement) (expr.Task, error) {
+func (m *Planner) VisitPreparedStmt(stmt *expr.PreparedStatement) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitPreparedStmt %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }
-func (m *Planner) VisitCommand(stmt *expr.SqlCommand) (expr.Task, error) {
+func (m *Planner) VisitCommand(stmt *expr.SqlCommand) (expr.Task, expr.VisitStatus, error) {
 	u.Debugf("VisitPreparedStmt %+v", stmt)
-	return nil, expr.ErrNotImplemented
+	return nil, expr.VisitError, expr.ErrNotImplemented
 }

--- a/plan/projection.go
+++ b/plan/projection.go
@@ -1,0 +1,81 @@
+package plan
+
+import (
+	"fmt"
+	"strings"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/datasource"
+	"github.com/araddon/qlbridge/expr"
+)
+
+type Projection struct {
+	Sql  *expr.SqlSelect
+	Proj *expr.Projection
+}
+type ProjectionSource struct {
+	Source *expr.SqlSource
+	Table  *datasource.Table
+	Proj   *expr.Projection
+}
+
+func NewProjectionStatic(proj *expr.Projection) *Projection {
+	return &Projection{Proj: proj}
+}
+
+// Final Projections project final select columns for result-writing
+func NewProjectionFinal(conf *datasource.RuntimeSchema, sqlSelect *expr.SqlSelect) (*Projection, error) {
+	s := &Projection{
+		Sql: sqlSelect,
+	}
+	err := s.loadFinal(conf, true)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+func (m *Projection) loadFinal(conf *datasource.RuntimeSchema, isFinal bool) error {
+
+	if len(m.Sql.From) == 0 {
+		return fmt.Errorf("no projection bc no from?")
+	}
+	u.Debugf("creating plan.Projection final %s", m.Sql.String())
+
+	m.Proj = expr.NewProjection()
+
+	//m.Sql.Rewrite()
+
+	for _, from := range m.Sql.From {
+		//u.Infof("info: %#v", from)
+		fromName := strings.ToLower(from.SourceName())
+		tbl, err := conf.Table(fromName)
+		if err != nil {
+			u.Errorf("could not get table: %v", err)
+			return err
+		} else if tbl == nil {
+			u.Errorf("no table? %v", from.Name)
+			return fmt.Errorf("Table not found %q", from.Name)
+		} else {
+
+			//u.Debugf("getting cols? %v   cols=%v", from.ColumnPositions(), len(cols))
+			for _, col := range from.Source.Columns {
+				//_, right, _ := col.LeftRight()
+				if schemaCol, ok := tbl.FieldMap[col.SourceField]; ok {
+					if isFinal {
+						if col.InFinalProjection() {
+							m.Proj.AddColumnShort(col.As, schemaCol.Type)
+						}
+					} else {
+						m.Proj.AddColumnShort(col.As, schemaCol.Type)
+					}
+					//u.Debugf("col %#v", col)
+					u.Infof("projection: %p add col: %v %v", m.Proj, col.As, schemaCol.Type.String())
+				} else {
+					u.Errorf("schema col not found:  vals=%#v", col)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/plan/projection.go
+++ b/plan/projection.go
@@ -74,7 +74,7 @@ func (m *Projection) loadFinal(conf *datasource.RuntimeSchema, isFinal bool) err
 					}
 					//u.Debugf("projection: %p add col: %v %v", m.Proj, col.As, schemaCol.Type.String())
 				} else {
-					u.Errorf("schema col not found:  vals=%#v", col)
+					u.Debugf("schema col not found:  vals=%#v", col)
 					if isFinal {
 						if col.InFinalProjection() {
 							m.Proj.AddColumnShort(col.As, value.StringType)
@@ -96,6 +96,7 @@ func projecectionForSourcePlan(plan *SourcePlan) error {
 	//u.Debugf("getting cols? %v   cols=%v", from.ColumnPositions(), len(cols))
 	for _, col := range plan.Source.Columns {
 		//_, right, _ := col.LeftRight()
+		//u.Debugf("projection final?%v tblnil?%v  col:%s", plan.Final, plan.Tbl == nil, col)
 		if plan.Tbl == nil {
 			if plan.Final {
 				if col.InFinalProjection() {
@@ -107,12 +108,15 @@ func projecectionForSourcePlan(plan *SourcePlan) error {
 		} else if schemaCol, ok := plan.Tbl.FieldMap[col.SourceField]; ok {
 			if plan.Final {
 				if col.InFinalProjection() {
+					//u.Infof("col add %v for %s", schemaCol.Type.String(), col)
 					plan.Proj.AddColumn(col, schemaCol.Type)
 				}
 			} else {
 				plan.Proj.AddColumn(col, schemaCol.Type)
 			}
 			//u.Debugf("projection: %p add col: %v %v", plan.Proj, col.As, schemaCol.Type.String())
+		} else if col.Star {
+			//
 		} else {
 			u.Errorf("schema col not found:  vals=%#v", col)
 		}

--- a/plan/projection.go
+++ b/plan/projection.go
@@ -72,8 +72,7 @@ func (m *Projection) loadFinal(conf *datasource.RuntimeSchema, isFinal bool) err
 					} else {
 						m.Proj.AddColumnShort(col.As, schemaCol.Type)
 					}
-					//u.Debugf("col %#v", col)
-					u.Infof("projection: %p add col: %v %v", m.Proj, col.As, schemaCol.Type.String())
+					//u.Debugf("projection: %p add col: %v %v", m.Proj, col.As, schemaCol.Type.String())
 				} else {
 					u.Errorf("schema col not found:  vals=%#v", col)
 					if isFinal {
@@ -113,8 +112,7 @@ func projecectionForSourcePlan(plan *SourcePlan) error {
 			} else {
 				plan.Proj.AddColumn(col, schemaCol.Type)
 			}
-			//u.Debugf("col %#v", col)
-			u.Infof("projection: %p add col: %v %v", plan.Proj, col.As, schemaCol.Type.String())
+			//u.Debugf("projection: %p add col: %v %v", plan.Proj, col.As, schemaCol.Type.String())
 		} else {
 			u.Errorf("schema col not found:  vals=%#v", col)
 		}

--- a/plan/visitor.go
+++ b/plan/visitor.go
@@ -1,0 +1,32 @@
+package plan
+
+import (
+	"github.com/araddon/qlbridge/expr"
+)
+
+// Task is the interface for execution/plan
+type Task interface {
+	Run(ctx *expr.Context) error
+	Close() error
+}
+
+// Visitor defines the Visit Pattern, so our expr package can
+//   expect implementations from downstream packages
+//   in our case: planner(s), job builder, execution engine
+//
+type Visitor interface {
+	VisitPreparedStmt(stmt *expr.PreparedStatement) (expr.Task, expr.VisitStatus, error)
+	VisitSelect(stmt *expr.SqlSelect) (expr.Task, expr.VisitStatus, error)
+	VisitInsert(stmt *expr.SqlInsert) (expr.Task, expr.VisitStatus, error)
+	VisitUpsert(stmt *expr.SqlUpsert) (expr.Task, expr.VisitStatus, error)
+	VisitUpdate(stmt *expr.SqlUpdate) (expr.Task, expr.VisitStatus, error)
+	VisitDelete(stmt *expr.SqlDelete) (expr.Task, expr.VisitStatus, error)
+	VisitShow(stmt *expr.SqlShow) (expr.Task, expr.VisitStatus, error)
+	VisitDescribe(stmt *expr.SqlDescribe) (expr.Task, expr.VisitStatus, error)
+	VisitCommand(stmt *expr.SqlCommand) (expr.Task, expr.VisitStatus, error)
+}
+
+// Interface for sub-select Tasks of the Select Statement, sub-selects
+type SourceVisitor interface {
+	VisitSourceSelect(plan *SourcePlan) (expr.Task, expr.VisitStatus, error)
+}


### PR DESCRIPTION
By allowing the accept/planning of Where, Source, Join etc to be implemented as much of possible in QLBridge, and allowing datasource implementers to minimize what they over-ride.

* remove sourcetask
* allow Accept, VisitSelect etc to poly-fill based on what is removed


**TODO**
* [x] implement `schema.Table(name)` in datasource
* [ ] address `select @@variable` type queries in Planner/builder
