### PR TITLE
WIP add test for filterql keywords

### DIFF
--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -126,3 +126,20 @@ func TestFilterQLAstCheck(t *testing.T) {
 	assert.Tf(t, f1.Expr != nil, "")
 	assert.Tf(t, f1.Expr.String() == "EXISTS datefield", "%#v", f1.Expr.String())
 }
+
+func TestFilterQLKeywords(t *testing.T) {
+	ql := `
+		FILTER 
+		  -- Test filter
+			AND (
+				created < "now-24h",
+				deleted == false
+			)
+		FROM accounts
+		ALIAS new_accounts
+		LIMIT 100
+	`
+	req, err := ParseFilterQL(ql)
+	assert.Equal(t, nil, err)
+	assert.NotEqual(t, nil, req)
+}


### PR DESCRIPTION
This test fails:

```
~/go/src/github.com/araddon/qlbridge/expr$ go test -v -vv -run Keyw
=== RUN TestFilterQLKeywords
2015/11/30 13:09:59.392317 lexer.go:1410: error looking for end of statement: 'ROM accounts
		ALIAS new_accounts
		LIMIT 10'
2015/11/30 13:09:59.392378 parse_filterql.go:229: Could not parse filters expected column but got: Token{Type:"Error" Value:""}
--- FAIL: TestFilterQLKeywords (0.00s)
	assert.go:15: /home/schmichael/go/src/github.com/araddon/qlbridge/expr/parse_filterql_test.go:143
	assert.go:24: ! nil != &errors.errorString{s:"expected column but got: Token{Type:\"Error\" Value:\"\"}"}
FAIL
exit status 1
FAIL	github.com/araddon/qlbridge/expr	0.003s
```