### PR TITLE
New contains native keyword

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -255,7 +255,7 @@ TODO:
 --------------------------------------
 O -> A {( "||" | OR  ) A}
 A -> C {( "&&" | AND ) C}
-C -> P {( "==" | "!=" | ">" | ">=" | "<" | "<=" | "LIKE" | "IN" ) P}
+C -> P {( "==" | "!=" | ">" | ">=" | "<" | "<=" | "LIKE" | "IN" | "CONTAINS") P}
 P -> M {( "+" | "-" ) M}
 M -> F {( "*" | "/" ) F}
 F -> v | "(" O ")" | "!" O | "-" O
@@ -363,7 +363,7 @@ func (t *Tree) cInner(n Node, depth int) Node {
 		//u.Debugf("cInner:  tok:  cur=%v peek=%v n=%v", t.Cur(), t.Peek(), n.String())
 		switch cur := t.Cur(); cur.T {
 		case lex.TokenEqual, lex.TokenEqualEqual, lex.TokenNE, lex.TokenGT, lex.TokenGE,
-			lex.TokenLE, lex.TokenLT, lex.TokenLike:
+			lex.TokenLE, lex.TokenLT, lex.TokenLike, lex.TokenContains:
 			t.Next()
 			n = NewBinaryNode(cur, n, t.P(depth+1))
 		case lex.TokenBetween:
@@ -694,12 +694,20 @@ arrayLoop:
 			break arrayLoop
 		case lex.TokenValue:
 			vals = append(vals, value.NewStringValue(tok.V))
-		case lex.TokenFloat, lex.TokenInteger:
+		case lex.TokenInteger:
 			fv, err := strconv.ParseFloat(tok.V, 64)
 			if err == nil {
 				vals = append(vals, value.NewNumberValue(fv))
+			} else {
+				return value.NilValueVal, err
 			}
-			return value.NilValueVal, err
+		case lex.TokenFloat:
+			fv, err := strconv.ParseFloat(tok.V, 64)
+			if err == nil {
+				vals = append(vals, value.NewNumberValue(fv))
+			} else {
+				return value.NilValueVal, err
+			}
 		default:
 			return value.NilValueVal, fmt.Errorf("Could not recognize token: %v", tok)
 		}

--- a/expr/parse_filterql.go
+++ b/expr/parse_filterql.go
@@ -509,7 +509,7 @@ func (m *filterQLParser) parseFilters(depth int, filtersNegate bool, filtersOp *
 			//u.Infof("%d %p filters: %s", depth, filters, filters.String())
 
 		case lex.TokenUdfExpr, lex.TokenIdentity, lex.TokenLike, lex.TokenExists, lex.TokenBetween,
-			lex.TokenIN, lex.TokenValue, lex.TokenInclude:
+			lex.TokenIN, lex.TokenValue, lex.TokenInclude, lex.TokenContains:
 
 			if op != nil {
 				u.Errorf("should not have op on Clause? %v", m.Cur())
@@ -582,7 +582,7 @@ func (m *filterQLParser) parseFilterClause(depth int, negate bool) (*FilterExpr,
 		fe.Expr = tree.Root
 
 	case lex.TokenIdentity, lex.TokenLike, lex.TokenExists, lex.TokenBetween,
-		lex.TokenIN, lex.TokenValue:
+		lex.TokenIN, lex.TokenValue, lex.TokenContains:
 
 		if m.Cur().T == lex.TokenIdentity && strings.ToLower(m.Cur().V) == "include" {
 			// TODO:  this is a bug in lexer ...

--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -30,6 +30,8 @@ func parseFilterQlTest(t *testing.T, ql string) {
 
 func TestFilterQlRoundTrip(t *testing.T) {
 
+	parseFilterQlTest(t, `FILTER email CONTAINS "gmail.com"`)
+
 	parseFilterQlTest(t, `
 		FILTER OR ( 
 			AND (

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -255,10 +255,9 @@ func (l *Lexer) PeekWord() string {
 				l.peekedWord = l.input[l.pos+skipWs : l.pos+i]
 				return l.peekedWord
 			} else if r == '(' {
-				// regardless of being short, lets treet like word
+				// regardless of being short, lets treat like word
 				return string(r)
 			}
-
 		}
 	}
 	//u.Infof("hm:   '%v'", l.input[l.pos+skipWs:l.pos+i])
@@ -2245,7 +2244,7 @@ func LexExpression(l *Lexer) StateFn {
 	switch word {
 	case "as":
 		return nil
-	case "in", "like", "between": // what is complete list here?
+	case "in", "like", "between", "contains": // what is complete list here?
 		switch word {
 		case "in":
 			l.ConsumeWord(word)
@@ -2255,6 +2254,15 @@ func LexExpression(l *Lexer) StateFn {
 		case "like":
 			l.ConsumeWord(word)
 			l.Emit(TokenLike)
+			return LexExpressionOrIdentity
+		case "contains":
+			l.ConsumeWord(word)
+			if l.Peek() == '(' {
+				l.Emit(TokenUdfExpr)
+				l.Push("LexExpression", l.clauseState())
+				return LexExpressionParens
+			}
+			l.Emit(TokenContains)
 			return LexExpressionOrIdentity
 		case "between":
 			l.ConsumeWord(word)

--- a/lex/token.go
+++ b/lex/token.go
@@ -87,7 +87,7 @@ const (
 	TokenLeftBrace    TokenType = 25 // {
 	TokenRightBrace   TokenType = 26 // }
 
-	// Logical Evaluation/expression inputs and operations
+	//  operand related tokens
 	TokenMinus            TokenType = 60 // -
 	TokenPlus             TokenType = 61 // +
 	TokenPlusPlus         TokenType = 62 // ++
@@ -117,6 +117,7 @@ const (
 	TokenFalse            TokenType = 86 // False
 	TokenIs               TokenType = 87 // IS
 	TokenNull             TokenType = 88 // NULL
+	TokenContains         TokenType = 89 // CONTAINS
 
 	// ql top-level keywords, these first keywords determine parser
 	TokenPrepare   TokenType = 200
@@ -264,6 +265,7 @@ var (
 		TokenBetween:    {Kw: "between", Description: "between"},
 		TokenIs:         {Kw: "is", Description: "IS"},
 		TokenNull:       {Kw: "null", Description: "NULL"},
+		TokenContains:   {Kw: "contains", Description: "contains"},
 
 		// Identity ish bools
 		TokenTrue:  {Kw: "true", Description: "True"},

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 
 	u "github.com/araddon/gou"
@@ -201,8 +202,21 @@ func Eval(ctx expr.EvalContext, arg expr.Node) (value.Value, bool) {
 		return value.NewStringValue(argVal.Text), true
 	case nil:
 		return nil, false
+	case *expr.ValueNode:
+		if argVal.Value == nil {
+			return nil, false
+		}
+		switch val := argVal.Value.(type) {
+		case *value.NilValue, value.NilValue:
+			return nil, false
+		case value.SliceValue:
+			//u.Warnf("got slice? %#v", argVal)
+			return val, true
+		}
+		u.Errorf("Unknonwn node type:  %#v", argVal.Value)
+		panic(ErrUnknownNodeType)
 	default:
-		u.Errorf("Unknonwn node type:  %T", argVal)
+		u.Errorf("Unknonwn node type:  %#v", arg)
 		panic(ErrUnknownNodeType)
 	}
 }
@@ -211,6 +225,14 @@ func (e *State) Walk(arg expr.Node) (value.Value, bool) {
 	return Eval(e.ContextReader, arg)
 }
 
+// Binary operands:   =, ==, !=, OR, AND, >, <, >=, <=, LIKE, contains
+//
+//       x == y,   x = y
+//       x != y
+//       x OR y
+//       x > y
+//       x < =
+//
 func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool) {
 	ar, aok := Eval(ctx, node.Args[0])
 	br, bok := Eval(ctx, node.Args[1])
@@ -338,7 +360,7 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool)
 				}
 				return value.NewBoolValue(true), true
 			default:
-				u.Warnf("unsupported op: %v", node.Operator)
+				u.Debugf("unsupported op: %v", node.Operator)
 				return nil, false
 			}
 		case value.BoolValue:
@@ -350,7 +372,7 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool)
 				case lex.TokenNE:
 					return value.NewBoolValue(value.BoolStringVal(at.Val()) != bt.Val()), true
 				default:
-					u.Warnf("unsupported op: %v", node.Operator)
+					u.Debugf("unsupported op: %v", node.Operator)
 					return nil, false
 				}
 			} else {
@@ -378,6 +400,52 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool)
 				u.Errorf("at?%T  %v  coerce?%v bt? %T     %v", at, at.Value(), at.CanCoerce(stringRv), br, br)
 			}
 		}
+	case value.SliceValue:
+		switch node.Operator.T {
+		case lex.TokenContains:
+			switch br.(type) {
+			case nil, value.NilValue:
+				return nil, false
+			case value.StringValue:
+				// [x,y,z] contains str
+				for _, val := range at.Val() {
+					//u.Infof("str contains? %v %v", val.Value(), br.Value())
+					if eq, _ := value.Equal(val, br); eq {
+						return value.BoolValueTrue, true
+					}
+				}
+				return value.BoolValueFalse, true
+			case value.IntValue:
+				// [] contains int
+				for _, val := range at.Val() {
+					//u.Infof("int contains? %v %v", val.Value(), br.Value())
+					if eq, _ := value.Equal(val, br); eq {
+						return value.BoolValueTrue, true
+					}
+				}
+				return value.BoolValueFalse, true
+			}
+		}
+		return nil, false
+	case value.StringsValue:
+		switch node.Operator.T {
+		case lex.TokenContains:
+			switch bv := br.(type) {
+			case value.StringValue:
+				// [x,y,z] contains str
+				for _, val := range at.Val() {
+					//u.Infof("str contains? %v %v", val, bv.Val())
+					if val == bv.Val() {
+						return value.BoolValueTrue, true
+					}
+					// if strings.Contains(val, bv.Val()) {
+					// 	return value.BoolValueTrue, true
+					// }
+				}
+				return value.BoolValueFalse, true
+			}
+		}
+		return nil, false
 	case nil, value.NilValue:
 		switch node.Operator.T {
 		case lex.TokenLogicAnd:
@@ -785,7 +853,14 @@ func operateStrings(op lex.Token, av, bv value.StringValue) value.Value {
 			return value.BoolValueFalse
 		}
 		return value.BoolValueTrue
-
+	case lex.TokenContains:
+		if len(a) == 0 || len(b) == 0 {
+			return value.BoolValueFalse
+		}
+		if strings.Contains(a, b) {
+			return value.BoolValueTrue
+		}
+		return value.BoolValueFalse
 	case lex.TokenLike: // a(value) LIKE b(pattern)
 		match, err := glob.Match(b, a)
 		if err != nil {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -52,8 +52,10 @@ var (
 		"hits":    value.NewMapIntValue(map[string]int64{"google.com": 5, "bing.com": 1}),
 		"email":   value.NewStringValue("bob@bob.com"),
 	})
-	// vmTests = []vmTest{
-	// }
+	vmTestsx = []vmTest{
+		// Native Contains keyword
+		vmt(`[1,2,3] contains int5`, false, noError),
+	}
 	// list of tests
 	vmTests = []vmTest{
 
@@ -70,6 +72,15 @@ var (
 		vmt(`not(contains(key,"-")) AND not(contains(email,"@"))`, false, noError),
 		vmt(`not(contains(key,"-")) OR not(contains(email,"@"))`, true, noError),
 		vmt(`not(contains(key,"-")) OR not(contains(not_real,"@"))`, true, noError),
+
+		// Native Contains keyword
+		vmt(`[1,2,3] contains int5`, false, noError),
+		vmt(`[1,2,3,5] contains int5`, true, noError),
+		vmt(`email contains "bob"`, true, noError),
+		vmt(`urls contains "abc"`, true, noError),
+		// Should this be correct?  By "Contains" do we change behavior
+		// depending on if is array, and we mean equality on array entry or?
+		vmt(`urls contains "ab"`, false, noError),
 
 		// Between:  Tri Node Tests
 		vmt(`10 BETWEEN 1 AND 50`, true, noError),


### PR DESCRIPTION
Not entirely sure what the behavior of contains should be:

1.  In event   `x contains y` x is array, then it should be equality operand of y against all members of x?
2.  in event `x contains y` x is scalar string, then it is string contains operand?
