### PR TITLE
Filterql vm, DateMath, ContextWrapper (read-structs from vm)

### DIFF
--- a/datasource/context.go
+++ b/datasource/context.go
@@ -156,8 +156,7 @@ func (m *UrlValuesMsg) Body() interface{} { return m.body }
 func (m *UrlValuesMsg) String() string    { return m.body.String() }
 
 type ContextSimple struct {
-	Data map[string]value.Value
-	//Rows   []map[string]value.Value
+	Data   map[string]value.Value
 	ts     time.Time
 	cursor int
 	keyval uint64
@@ -168,6 +167,13 @@ func NewContextSimple() *ContextSimple {
 }
 func NewContextSimpleData(data map[string]value.Value) *ContextSimple {
 	return &ContextSimple{Data: data, ts: time.Now(), cursor: 0}
+}
+func NewContextSimpleNative(data map[string]interface{}) *ContextSimple {
+	vals := make(map[string]value.Value)
+	for k, v := range data {
+		vals[k] = value.NewValue(v)
+	}
+	return &ContextSimple{Data: vals, ts: time.Now(), cursor: 0}
 }
 func NewContextSimpleTs(data map[string]value.Value, ts time.Time) *ContextSimple {
 	return &ContextSimple{Data: data, ts: ts, cursor: 0}

--- a/datasource/context_test.go
+++ b/datasource/context_test.go
@@ -53,6 +53,10 @@ func TestNested(t *testing.T) {
 
 func checkval(t *testing.T, r expr.ContextReader, key string, expected value.Value) {
 	val, ok := r.Get(key)
-	assert.T(t, ok)
-	assert.Equalf(t, expected, val, "%s expected: %v  got:%v", key, expected, val)
+	assert.Tf(t, ok, "expected key:%s =%v", key, expected.Value())
+	if val == nil {
+		t.Errorf("not value for %v", key)
+	} else {
+		assert.Equalf(t, expected.Value(), val.Value(), "%s expected: %v  got:%v", key, expected.Value(), val.Value())
+	}
 }

--- a/datasource/context_wrapper.go
+++ b/datasource/context_wrapper.go
@@ -1,0 +1,299 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package datasource
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"time"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/value"
+)
+
+type ContextWrapper struct {
+	val reflect.Value
+	s   *state
+}
+
+func NewContextWrapper(val interface{}) *ContextWrapper {
+	s := state{}
+	return &ContextWrapper{reflect.ValueOf(val), &s}
+}
+func (m *ContextWrapper) Get(key string) (value.Value, bool) {
+	keyParts := strings.Split(key, ".")
+	dot := m.val
+	var final reflect.Value
+	ident := expr.NewIdentityNodeVal(key)
+	//u.Warnf("got dot: k:%s %#v  %v", key, dot, dot.Kind())
+	// Now if it's a method, it gets the arguments.
+	final = m.s.evalFieldChain(dot, dot, ident, keyParts, nil, final)
+	if final == zero {
+		//u.Warnf("final = zero?  %v", final)
+		return nil, false
+	}
+	//u.Warnf("done? final%v", final)
+	val := value.NewValueReflect(final)
+	if val == nil {
+		return nil, false
+	}
+	return val, true
+}
+func (m *ContextWrapper) Row() map[string]value.Value { return nil }
+func (m *ContextWrapper) Ts() time.Time               { return time.Time{} }
+
+// unwind pointers, etc to find either the value or flag indicating was nil
+func findValue(v reflect.Value) (reflect.Value, bool) {
+	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+		if v.IsNil() {
+			return v, true
+		}
+		if v.Kind() == reflect.Interface && v.NumMethod() > 0 {
+			break
+		}
+	}
+	return v, false
+}
+
+var zero reflect.Value
+
+type state struct {
+	stack []namedvar
+}
+
+// our stack vars that have come from strings in vm eval engine
+//    such as "user.Name" will try to find struct value with .Name
+type namedvar struct {
+	name  string
+	value reflect.Value
+}
+
+var (
+	errorType       = reflect.TypeOf((*error)(nil)).Elem()
+	fmtStringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+)
+
+func (s *state) errorf(format string, args ...interface{}) {
+	err := fmt.Errorf(format, args...)
+	u.Errorf("error %v", err)
+	panic(err)
+}
+
+func errRecover(errp *error) {
+	e := recover()
+	if e != nil {
+		switch err := e.(type) {
+		case runtime.Error:
+			panic(e)
+		case error:
+			// these errors have surfaced internally, we can capture them
+			*errp = err
+		default:
+			panic(e)
+		}
+	}
+}
+
+// evalFieldChain evaluates .X.Y.Z possibly followed by arguments.
+// dot is the environment in which to evaluate arguments, while
+// receiver is the value being walked along the chain.
+func (s *state) evalFieldChain(dot, receiver reflect.Value, node *expr.IdentityNode, ident []string, args []expr.Node, final reflect.Value) reflect.Value {
+	n := len(ident)
+	for i := 0; i < n-1; i++ {
+		receiver = s.evalField(dot, ident[i], node, nil, zero, receiver)
+	}
+	// Now if it's a method, it gets the arguments.
+	return s.evalField(dot, ident[n-1], node, args, final, receiver)
+}
+
+// func (s *state) evalFunction(dot reflect.Value, node *expr.IdentityNode, cmd expr.Node, args []expr.Node, final reflect.Value) reflect.Value {
+// 	name := node.Text
+// 	function, ok := findFunction(name, s.tmpl)
+// 	if !ok {
+// 		s.errorf("%q is not a defined function", name)
+// 	}
+// 	return s.evalCall(dot, function, cmd, name, args, final)
+// }
+
+func lowerFieldMatch(fieldName string) func(string) bool {
+	lowerField := strings.ToLower(fieldName)
+	return func(field string) bool {
+		//u.Debugf("check: %s == %s ?", field, lowerField)
+		return strings.ToLower(field) == lowerField
+	}
+}
+
+// evalField evaluates an expression like (.Field) or (.Field arg1 arg2).
+// The 'final' argument represents the return value from the preceding
+// value of the pipeline, if any.
+func (s *state) evalField(dot reflect.Value, fieldName string, node expr.Node, args []expr.Node, final, receiver reflect.Value) reflect.Value {
+
+	//u.Debugf("evalField: valid?%v", receiver.IsValid())
+	if !receiver.IsValid() {
+		//u.Warnf("bailing")
+		return zero
+	}
+	typ := receiver.Type()
+	receiver, _ = findValue(receiver)
+	// Unless it's an interface, need to get to a value of type *T to guarantee
+	// we see all methods of T and *T.
+	ptr := receiver
+	if ptr.Kind() != reflect.Interface && ptr.CanAddr() {
+		ptr = ptr.Addr()
+	}
+	if method := ptr.MethodByName(fieldName); method.IsValid() {
+		//u.Warnf("unimplemented method: %v", fieldName)
+		return s.evalCall(dot, method, node, fieldName, args, final)
+	}
+	hasArgs := len(args) > 1 || final.IsValid()
+	// It's not a method; must be a field of a struct or an element of a map. The receiver must not be nil.
+	receiver, isNil := findValue(receiver)
+	//u.Debugf("fld:%s  receiver kind():%v  val: %v", fieldName, receiver.Kind(), receiver)
+	if isNil {
+		s.errorf("nil pointer evaluating %s.%s", typ, fieldName)
+	}
+	switch receiver.Kind() {
+	case reflect.Struct:
+		tField, ok := receiver.Type().FieldByName(fieldName)
+		if !ok {
+			tField, ok = receiver.Type().FieldByNameFunc(lowerFieldMatch(fieldName))
+		}
+		//u.Infof("got field? %v", fieldName, tField)
+		if ok {
+			field := receiver.FieldByIndex(tField.Index)
+			if tField.PkgPath != "" { // field is unexported
+				s.errorf("%s is an unexported field of struct type %s", fieldName, typ)
+			}
+			// If it's a function, we must call it.
+			if hasArgs {
+				s.errorf("%s has arguments but cannot be invoked as function", fieldName)
+			}
+			//u.Infof("found it %s:%v", fieldName, field)
+			return field
+		}
+		//context reader doesn't care about empty values
+		return zero
+	case reflect.Map:
+		// If it's a map, attempt to use the field name as a key.
+		nameVal := reflect.ValueOf(fieldName)
+		if nameVal.Type().AssignableTo(receiver.Type().Key()) {
+			if hasArgs {
+				s.errorf("%s is not a method but has arguments", fieldName)
+			}
+			result := receiver.MapIndex(nameVal)
+			if !result.IsValid() {
+				u.Errorf("could not evaluate %v", nameVal)
+				// switch s.tmpl.option.missingKey {
+				// case mapInvalid:
+				// 	// Just use the invalid value.
+				// case mapZeroValue:
+				// 	result = reflect.Zero(receiver.Type().Elem())
+				// case mapError:
+				// 	s.errorf("map has no entry for key %q", fieldName)
+				// }
+			}
+			return result
+		}
+	}
+	s.errorf("can't evaluate field %s in type %s", fieldName, typ)
+	panic("not reached")
+}
+
+func (s *state) evalCall(dot, fun reflect.Value, node expr.Node, name string, args []expr.Node, final reflect.Value) reflect.Value {
+	typ := fun.Type()
+	if !goodFunc(typ) {
+		// TODO: This could still be a confusing error; maybe goodFunc should provide info.
+		s.errorf("can't call method/function %q with %d results", name, typ.NumOut())
+	}
+	// Build the arg list.
+	argv := make([]reflect.Value, 0)
+	result := fun.Call(argv)
+	// If we have an error that is not nil, stop execution and return that error to the caller.
+	if len(result) == 2 && !result[1].IsNil() {
+		s.errorf("error calling %s: %s", name, result[1].Interface().(error))
+	}
+	return result[0]
+}
+
+/*
+// evalCall executes a function or method call. If it's a method, fun already has the receiver bound, so
+// it looks just like a function call.  The arg list, if non-nil, includes (in the manner of the shell), arg[0]
+// as the function itself.
+func (s *state) evalCall(dot, fun reflect.Value, node expr.Node, name string, args []expr.Node, final reflect.Value) reflect.Value {
+	if args != nil {
+		args = args[1:] // Zeroth arg is function name/node; not passed to function.
+	}
+	typ := fun.Type()
+	numIn := len(args)
+	if final.IsValid() {
+		numIn++
+	}
+	numFixed := len(args)
+	if typ.IsVariadic() {
+		numFixed = typ.NumIn() - 1 // last arg is the variadic one.
+		if numIn < numFixed {
+			s.errorf("wrong number of args for %s: want at least %d got %d", name, typ.NumIn()-1, len(args))
+		}
+	} else if numIn < typ.NumIn()-1 || !typ.IsVariadic() && numIn != typ.NumIn() {
+		s.errorf("wrong number of args for %s: want %d got %d", name, typ.NumIn(), len(args))
+	}
+	if !goodFunc(typ) {
+		// TODO: This could still be a confusing error; maybe goodFunc should provide info.
+		s.errorf("can't call method/function %q with %d results", name, typ.NumOut())
+	}
+	// Build the arg list.
+	argv := make([]reflect.Value, numIn)
+	// Args must be evaluated. Fixed args first.
+	i := 0
+	for ; i < numFixed && i < len(args); i++ {
+		argv[i] = s.evalArg(dot, typ.In(i), args[i])
+	}
+	// Now the ... args.
+	if typ.IsVariadic() {
+		argType := typ.In(typ.NumIn() - 1).Elem() // Argument is a slice.
+		for ; i < len(args); i++ {
+			argv[i] = s.evalArg(dot, argType, args[i])
+		}
+	}
+	// Add final value if necessary.
+	if final.IsValid() {
+		t := typ.In(typ.NumIn() - 1)
+		if typ.IsVariadic() {
+			if numIn-1 < numFixed {
+				// The added final argument corresponds to a fixed parameter of the function.
+				// Validate against the type of the actual parameter.
+				t = typ.In(numIn - 1)
+			} else {
+				// The added final argument corresponds to the variadic part.
+				// Validate against the type of the elements of the variadic slice.
+				t = t.Elem()
+			}
+		}
+		argv[i] = s.validateType(final, t)
+	}
+	result := fun.Call(argv)
+	// If we have an error that is not nil, stop execution and return that error to the caller.
+	if len(result) == 2 && !result[1].IsNil() {
+		s.at(node)
+		s.errorf("error calling %s: %s", name, result[1].Interface().(error))
+	}
+	return result[0]
+}
+*/
+
+// goodFunc checks that the function or method has the right result signature.
+func goodFunc(typ reflect.Type) bool {
+	// We allow functions with 1 result or 2 results where the second is an error.
+	switch {
+	case typ.NumOut() == 1:
+		return true
+	case typ.NumOut() == 2 && typ.Out(1) == errorType:
+		return true
+	}
+	return false
+}

--- a/datasource/context_wrapper_test.go
+++ b/datasource/context_wrapper_test.go
@@ -1,0 +1,76 @@
+package datasource
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/araddon/dateparse"
+	u "github.com/araddon/gou"
+	//"github.com/bmizerany/assert"
+
+	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/value"
+)
+
+// Our test struct, try as many different field types as possible
+type User struct {
+	Name          string
+	Created       time.Time
+	Updated       *time.Time
+	Authenticated bool
+	HasSession    *bool
+	Roles         []string
+	BankAmount    float64
+	Address       struct {
+		City string
+		Zip  int
+	}
+	Data    json.RawMessage
+	Context u.JsonHelper
+}
+
+func (m *User) FullName() string {
+	return m.Name + ", Jedi"
+}
+
+func TestStructWrapper(t *testing.T) {
+
+	t1, _ := dateparse.ParseAny("12/18/2015")
+	tr := true
+	user := &User{
+		Name:          "Yoda",
+		Created:       t1,
+		Updated:       &t1,
+		Authenticated: true,
+		HasSession:    &tr,
+		Roles:         []string{"admin", "api"},
+		BankAmount:    55.5,
+	}
+
+	readers := []expr.ContextReader{
+		NewContextWrapper(user),
+		NewContextSimpleNative(map[string]interface{}{
+			"str1": "str1",
+			"int1": 1,
+			"t1":   t1,
+			"Name": "notyoda",
+		}),
+	}
+
+	nc := NewNestedContextReader(readers, time.Now())
+	expected := value.NewMapValue(map[string]interface{}{
+		"str1":          "str1",
+		"int1":          1,
+		"Name":          "Yoda",
+		"Authenticated": true,
+		"bankamount":    55.5,
+		"FullName":      "Yoda, Jedi",
+		"Roles":         []string{"admin", "api"},
+	})
+
+	for k, v := range expected.Val() {
+		//u.Infof("k:%v v:%#v", k, v)
+		checkval(t, nc, k, v)
+	}
+}

--- a/datasource/datatypes.go
+++ b/datasource/datatypes.go
@@ -11,7 +11,25 @@ import (
 	u "github.com/araddon/gou"
 )
 
-type TimeValue time.Time
+// A collection of data-types that implment database/sql Scan() interface
+// for converting byte fields to richer go data types
+
+type (
+
+	// Convert string/bytes to time.Time
+	//  auto-parses a variety of different date formats
+	//  that are supported in http://godoc.org/github.com/araddon/dateparse
+	TimeValue time.Time
+
+	// Convert json to array of strings
+	StringArray []string
+
+	// convert json bytes
+	JsonWrapper json.RawMessage
+
+	// json
+	JsonHelperScannable u.JsonHelper
+)
 
 func (m *TimeValue) MarshalJSON() ([]byte, error) {
 	by, err := time.Time(*m).MarshalJSON()
@@ -25,7 +43,6 @@ func (m *TimeValue) UnmarshalJSON(data []byte) error {
 		*m = TimeValue(t)
 	}
 	return err
-
 }
 
 func (m TimeValue) Value() (driver.Value, error) {
@@ -84,8 +101,6 @@ func (m *TimeValue) Unmarshal(v interface{}) error {
 	return fmt.Errorf("not implemented")
 }
 
-type JsonWrapper json.RawMessage
-
 func (m *JsonWrapper) MarshalJSON() ([]byte, error) { return *m, nil }
 
 // Unmarshall bytes into this typed struct
@@ -127,8 +142,6 @@ func (m *JsonWrapper) Unmarshal(v interface{}) error {
 	return json.Unmarshal([]byte(*m), v)
 }
 
-type JsonHelperScannable u.JsonHelper
-
 func (m *JsonHelperScannable) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.JsonHelper(*m))
 }
@@ -144,7 +157,6 @@ func (m *JsonHelperScannable) UnmarshalJSON(data []byte) error {
 	}
 	*m = JsonHelperScannable(jh)
 	return nil
-
 }
 
 // This is the go sql/driver interface we need to implement to allow
@@ -180,8 +192,6 @@ func (m *JsonHelperScannable) Scan(src interface{}) error {
 // func (m *JsonHelperScannable) Unmarshal(v interface{}) error {
 // 	return json.Unmarshal([]byte(*m), v)
 // }
-
-type StringArray []string
 
 func (m *StringArray) MarshalJSON() ([]byte, error) {
 	by, err := json.Marshal(*m)

--- a/exec/join.go
+++ b/exec/join.go
@@ -92,7 +92,7 @@ func (m *JoinKey) Run(context *expr.Context) error {
 						}
 						vals[i] = joinVal.ToString()
 					}
-					//u.Infof("joinkey: %v row:%v", vals, mt.Row())
+					//u.Infof("joinkey: %v row:%v", vals, mt)
 					key := strings.Join(vals, string(byte(0)))
 					mt.SetKeyHashed(key)
 					outCh <- mt
@@ -210,7 +210,7 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 					case *datasource.SqlDriverMessageMap:
 						key := mt.Key()
 						if key == "" {
-							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt.Row())
+							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt)
 							u.Errorf("no key? %#v  %v", mt, fatalErr)
 							close(m.TaskBase.sigCh)
 							return
@@ -248,7 +248,7 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 					case *datasource.SqlDriverMessageMap:
 						key := mt.Key()
 						if key == "" {
-							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt.Row())
+							fatalErr = fmt.Errorf(`To use Join msgs must have keys but got "" for %+v`, mt)
 							u.Errorf("no key? %#v  %v", mt, fatalErr)
 							close(m.TaskBase.sigCh)
 							return
@@ -276,7 +276,7 @@ func (m *JoinMerge) Run(context *expr.Context) error {
 			//u.Debugf("msgsct: %v   msgs:%#v", len(msgs), msgs)
 			for _, msg := range msgs {
 				//outCh <- datasource.NewUrlValuesMsg(i, msg)
-				//u.Debugf("i:%d   msg:%#v", i, msg.Row())
+				//u.Debugf("i:%d   msg:%#v", i, msg)
 				msg.IdVal = i
 				i++
 				outCh <- msg
@@ -294,9 +294,6 @@ func (m *JoinMerge) mergeValueMessages(lmsgs, rmsgs []*datasource.SqlDriverMessa
 	for _, lm := range lmsgs {
 		//u.Warnf("nice SqlDriverMessageMap: %#v", lmt)
 		for _, rm := range rmsgs {
-			// for k, val := range rmt.Row() {
-			// 	u.Debugf("k=%v v=%v", k, val)
-			// }
 			vals := make([]driver.Value, len(m.colIndex))
 			vals = m.valIndexing(vals, lm.Values(), m.leftStmt.Source.Columns)
 			vals = m.valIndexing(vals, rm.Values(), m.rightStmt.Source.Columns)

--- a/exec/results.go
+++ b/exec/results.go
@@ -191,7 +191,7 @@ func msgToRow(msg datasource.Message, cols []string, dest []driver.Value) error 
 					dest[i] = val.Value()
 					//u.Infof("key=%v   val=%v", key, val)
 				} else if val == nil {
-					u.Errorf("could not evaluate? %v  %#v", key, mt.Row())
+					u.Errorf("could not evaluate? %v  %#v", key, mt)
 				} else {
 					u.Warnf("missing value? %v %T %v", key, val.Value(), val.Value())
 				}
@@ -205,7 +205,7 @@ func msgToRow(msg datasource.Message, cols []string, dest []driver.Value) error 
 				dest[i] = val.Value()
 				//u.Infof("key=%v   val=%v", key, val)
 			} else if val == nil {
-				u.Errorf("could not evaluate? %v  %#v", key, mt.Row())
+				u.Errorf("could not evaluate? %v  %#v", key, mt)
 			} else {
 				u.Warnf("missing value? %v %T %v", key, val.Value(), val.Value())
 			}

--- a/exec/where.go
+++ b/exec/where.go
@@ -74,7 +74,7 @@ func whereFilter(where expr.Node, task TaskRunner, cols map[string]*expr.Column)
 			whereValue, ok = evaluator(msgReader)
 		case *datasource.SqlDriverMessageMap:
 			whereValue, ok = evaluator(mt)
-			//u.Debugf("WHERE: result:%v T:%T  \n\trow:%#v \n\tvals:%#v", whereValue, msg, mt.Row(), mt.Values())
+			//u.Debugf("WHERE: result:%v T:%T  \n\trow:%#v \n\tvals:%#v", whereValue, msg, mt, mt.Values())
 			//u.Debugf("cols:  %#v", cols)
 		default:
 			if msgReader, ok := msg.(expr.ContextReader); ok {

--- a/expr/builtins/builtins.go
+++ b/expr/builtins/builtins.go
@@ -512,7 +512,9 @@ func SplitFunc(ctx expr.EvalContext, input value.Value, splitByV value.StringVal
 // Replace a string(s), accepts any number of parameters to replace
 //    replaces with ""
 //
-//     replace("/blog/index.html", "/blog","M2")  =>  /index.html
+//     replace("/blog/index.html", "/blog","")  =>  /index.html
+//     replace("/blog/index.html", "/blog")  =>  /index.html
+//     replace("/blog/index.html", "/blog/archive/","/blog")  =>  /blog/index.html
 //     replace(item, "M")
 //
 func Replace(ctx expr.EvalContext, vals ...value.Value) (value.StringValue, bool) {
@@ -520,17 +522,15 @@ func Replace(ctx expr.EvalContext, vals ...value.Value) (value.StringValue, bool
 		return value.EmptyStringValue, false
 	}
 	val1 := vals[0].ToString()
-	for _, v := range vals[1:] {
-		if v.Err() || v.Nil() {
-			return value.EmptyStringValue, false
-		} else if value.IsNilIsh(v.Rv()) {
-			return value.EmptyStringValue, false
-		}
-		v2 := v.ToString()
-		if len(v2) > 0 {
-			val1 = strings.Replace(val1, v2, "", -1)
-		}
+	arg := vals[1]
+	replaceWith := ""
+	if len(vals) == 3 {
+		replaceWith = vals[2].ToString()
 	}
+	if arg.Err() {
+		return value.EmptyStringValue, false
+	}
+	val1 = strings.Replace(val1, arg.ToString(), replaceWith, -1)
 	return value.NewStringValue(val1), true
 }
 

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	u "github.com/araddon/gou"
+	"github.com/bmizerany/assert"
+
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/value"
 	"github.com/araddon/qlbridge/vm"
-	"github.com/bmizerany/assert"
 )
 
 var _ = u.EMPTY
@@ -122,6 +123,8 @@ var builtinTests = []testBuiltins{
 
 	{`replace("M20:30","M")`, value.NewStringValue("20:30")},
 	{`replace("/search/for+stuff","/search/")`, value.NewStringValue("for+stuff")},
+	{`replace("M20:30","M","")`, value.NewStringValue("20:30")},
+	{`replace("M20:30","M","Hour ")`, value.NewStringValue("Hour 20:30")},
 
 	{`oneof("apples","oranges")`, value.NewStringValue("apples")},
 	{`oneof(notincontext,event)`, value.NewStringValue("hello")},

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -192,6 +192,8 @@ var builtinTests = []testBuiltins{
 	// ts2         = time.Date(2014, 4, 7, 0, 0, 0, 00, time.UTC)
 	// Eu style
 	{`todate("02/01/2006","07/04/2014")`, value.NewTimeValue(ts2)},
+	{`todate("Apr 7, 2014 4:58:55 PM")`, value.NewTimeValue(ts)},
+	{`todate("Apr 7, 2014 4:58:55 PM") < todate("now-3m")`, value.NewBoolValue(true)},
 
 	{`toint("5")`, value.NewIntValue(5)},
 	{`toint("hello")`, value.ErrValue},
@@ -234,8 +236,6 @@ var builtinTests = []testBuiltins{
 	{`hourofweek("Apr 7, 2014 4:58:55 PM")`, value.NewIntValue(40)},
 
 	{`totimestamp("Apr 7, 2014 4:58:55 PM")`, value.NewIntValue(1396889935)},
-
-	{`todate("Apr 7, 2014 4:58:55 PM")`, value.NewTimeValue(ts)},
 
 	{`exists(event)`, value.BoolValueTrue},
 	{`exists(price)`, value.BoolValueTrue},

--- a/expr/node.go
+++ b/expr/node.go
@@ -148,8 +148,10 @@ type (
 	// A negateable node requires a special type of String() function due to
 	// an enclosing urnary NOT being inserted into middle of string syntax
 	//
-	//   expression [NOT] IN ("a","b")
-	//   expression [NOT] BETWEEN expression AND expression
+	//   <expression> [NOT] IN ("a","b")
+	//   <expression> [NOT] BETWEEN <expression> AND <expression>
+	//   <expression> [NOT] LIKE <expression>
+	//   <expression> [NOT] CONTAINS <expression>
 	//
 	//  The ast would be similar to:
 	//       inNode := NewMultiArgNode(lex.Token{T:lex.TokenIN})
@@ -185,6 +187,7 @@ type (
 	}
 
 	// For evaluation storage
+	//    vm writes results to this after evaluation
 	ContextWriter interface {
 		Put(col SchemaInfo, readCtx ContextReader, v value.Value) error
 		Delete(row map[string]value.Value) error

--- a/expr/node.go
+++ b/expr/node.go
@@ -261,7 +261,7 @@ type (
 
 	// Binary node is   x op y, two nodes (left, right) and an operator
 	// operators can be a variety of:
-	//    +, -, *, %, /,
+	//    +, -, *, %, /, LIKE, CONTAINS
 	// Also, parenthesis may wrap these
 	BinaryNode struct {
 		Paren    bool
@@ -276,7 +276,10 @@ type (
 		Operator lex.Token
 	}
 
-	// UnaryNode holds one argument and an operator
+	// UnaryNode negates a single node argument
+	//
+	//   (  not <expression>  |   !<expression> )
+	//
 	//    !eq(5,6)
 	//    !true
 	//    !(true OR false)

--- a/expr/sql.go
+++ b/expr/sql.go
@@ -37,8 +37,8 @@ func init() {
 	starCols[0] = NewColumnFromToken(lex.Token{T: lex.TokenStar, V: "*"})
 }
 
-// The sqlStatement interface, to define the sql-types
-//  Select, Insert, Delete etc
+// The sqlStatement interface, to define the sql statement
+//  Select, Insert, Update, Delete, Command, Show, Describe etc
 type SqlStatement interface {
 	Node
 	Accept(visitor Visitor) (Task, VisitStatus, error)
@@ -54,7 +54,7 @@ type SqlSubStatement interface {
 }
 
 type (
-	// Prepared/Aliased SQL
+	// Prepared/Aliased SQL statement
 	PreparedStatement struct {
 		Alias     string
 		Statement SqlStatement

--- a/value/value.go
+++ b/value/value.go
@@ -278,6 +278,24 @@ func NewValue(goVal interface{}) Value {
 	return NilValueVal
 }
 
+func NewValueReflect(rv reflect.Value) Value {
+	switch rv.Kind() {
+	case reflect.String:
+		return NewStringValue(rv.String())
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
+		return NewIntValue(rv.Int())
+	case reflect.Float32, reflect.Float64:
+		return NewNumberValue(rv.Float())
+	case reflect.Bool:
+		return NewBoolValue(rv.Bool())
+	//case reflect.ValueOf(time.Time{}).Kind():
+	default:
+		return NewValue(rv.Interface())
+		//u.Warnf("not implemented %v", rv.Kind())
+	}
+	return nil
+}
+
 func ValueTypeFromRT(rt reflect.Type) ValueType {
 	switch rt {
 	case reflect.TypeOf(NilValue{}):

--- a/vm/filterqlvm.go
+++ b/vm/filterqlvm.go
@@ -1,0 +1,143 @@
+package vm
+
+import (
+	"fmt"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/lex"
+	"github.com/araddon/qlbridge/value"
+)
+
+var _ = u.EMPTY
+
+// Includer defines an interface used for resolving INCLUDE clauses into a
+// *FilterStatement. Implementations should return an error if the name cannot
+// be resolved.
+type Includer interface {
+	Include(name string) (*expr.FilterStatement, error)
+}
+
+type filterql struct {
+	inc Includer
+}
+
+func NewFilterVm(i Includer) *filterql {
+	return &filterql{inc: i}
+}
+
+// Matches executes a FilterQL query against an entity returning true if the
+// entity matches.
+func (q *filterql) Matches(cr expr.ContextReader, stmt *expr.FilterStatement) (bool, error) {
+	return q.matchesFilters(cr, stmt.Filter)
+}
+
+func (q *filterql) matchesFilters(cr expr.ContextReader, fs *expr.Filters) (bool, error) {
+	var and bool
+	switch fs.Op {
+	case lex.TokenAnd, lex.TokenLogicAnd:
+		and = true
+	case lex.TokenOr, lex.TokenLogicOr:
+		and = false
+	default:
+		return false, fmt.Errorf("unexpected op %v", fs.Op)
+	}
+
+	//u.Infof("filters and?%v  filter=%q", and, fs.String())
+	for _, filter := range fs.Filters {
+
+		matches, err := q.matchesFilter(cr, filter)
+		//u.Debugf("matches filter?%v  err=%q  f=%q", matches, err, filter.String())
+		if err != nil {
+			return false, err
+		}
+		if !and && matches {
+			// one of the expressions in an OR clause matched, shortcircuit true
+			if fs.Negate {
+				return false, nil
+			}
+			return true, nil
+		}
+		if and && !matches {
+			// one of the expressions in an AND clause did not match, shortcircuit false
+			if fs.Negate {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+	// no shortcircuiting, if and=true this means all expressions returned true...
+	// ...if and=false (OR) this means all expressions returned false.
+	if fs.Negate {
+		return !and, nil
+	}
+	return and, nil
+}
+
+func (q *filterql) matchesFilter(cr expr.ContextReader, exp *expr.FilterExpr) (bool, error) {
+	switch {
+	case exp.Include != "":
+
+		if exp.IncludeFilter == nil {
+			filterStmt, err := q.inc.Include(exp.Include)
+			if err != nil {
+				u.Warn(err)
+				return false, fmt.Errorf("failed to resolve INCLUDE %q: %v", exp.Include, err)
+			}
+			exp.IncludeFilter = filterStmt
+		}
+		doesMatch, err := q.Matches(cr, exp.IncludeFilter)
+		if err != nil {
+			return false, err
+		}
+
+		//u.Debugf("include? %q  negate?%v", exp.IncludeFilter.String(), exp.Negate)
+		if exp.Negate {
+			return !doesMatch, nil
+		}
+		return doesMatch, nil
+
+	case exp.Expr != nil:
+		// Hand it off to the single expression Evaluator
+		out, ok := Eval(cr, exp.Expr)
+		//u.Debugf("expr? %q out?%#v  ok?%v", exp.Expr.String(), out, ok)
+		if !ok || out == nil {
+			// VM unable to evaluate expression -> treat it as false
+			if exp.Negate {
+				return true, nil
+			}
+			return false, nil
+		}
+		//u.Infof("out? negate?%v  nil?%v err?%v  %#v", exp.Negate, out.Nil(), out.Err(), out.Value())
+		if out.Nil() {
+			return false, fmt.Errorf("unexpected empty output from %q", exp.Expr)
+		}
+		if out.Err() {
+			return false, fmt.Errorf("evaluation error: %v", out.Value())
+		}
+		if out.Type() != value.BoolType {
+			return false, fmt.Errorf("expression returned non-bool type: %s", out.Type())
+		}
+		outVal := out.Value().(bool)
+		if exp.Negate {
+			return !outVal, nil
+		}
+		return outVal, nil
+
+	case exp.Filter != nil:
+		doesMatch, err := q.matchesFilters(cr, exp.Filter)
+		if err != nil {
+			return false, err
+		}
+
+		u.Debugf("filter? %q  negate?%v", exp.IncludeFilter.String(), exp.Negate)
+		if exp.Negate {
+			return !doesMatch, nil
+		}
+		return doesMatch, nil
+
+	default:
+		return false, fmt.Errorf("empty expression")
+	}
+}

--- a/vm/filterqlvm.go
+++ b/vm/filterqlvm.go
@@ -131,7 +131,7 @@ func (q *filterql) matchesFilter(cr expr.ContextReader, exp *expr.FilterExpr) (b
 			return false, err
 		}
 
-		u.Debugf("filter? %q  negate?%v", exp.IncludeFilter.String(), exp.Negate)
+		//u.Debugf("filter? %q  negate?%v", exp.IncludeFilter.String(), exp.Negate)
 		if exp.Negate {
 			return !doesMatch, nil
 		}

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -1,9 +1,12 @@
 package vm
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/araddon/dateparse"
 	u "github.com/araddon/gou"
 	"github.com/bmizerany/assert"
 
@@ -13,34 +16,80 @@ import (
 
 var _ = u.EMPTY
 
+// Our test struct, try as many different field types as possible
+type User struct {
+	Name          string
+	Created       time.Time
+	Updated       *time.Time
+	Authenticated bool
+	HasSession    *bool
+	Roles         []string
+	BankAmount    float64
+	Address       struct {
+		City string
+		Zip  int
+	}
+	Data    json.RawMessage
+	Context u.JsonHelper
+}
+
+func (m *User) FullName() string {
+	return m.Name + ", Jedi"
+}
+
 func TestFilterQlVm(t *testing.T) {
 	t.Parallel()
 
-	e := datasource.NewContextSimpleNative(map[string]interface{}{
-		"name": "Yoda",
-		"city": "Peoria, IL",
-		"zip":  5,
-	})
+	t1, _ := dateparse.ParseAny("12/18/2015")
+	u.Infof("t1 %v", t1)
+	nminus1 := time.Now().Add(time.Hour * -1)
+	tr := true
+	user := &User{
+		Name:          "Yoda",
+		Created:       t1,
+		Updated:       &nminus1,
+		Authenticated: true,
+		HasSession:    &tr,
+		Roles:         []string{"admin", "api"},
+		BankAmount:    55.5,
+	}
+
+	readers := []expr.ContextReader{
+		datasource.NewContextWrapper(user),
+		datasource.NewContextSimpleNative(map[string]interface{}{
+			"city": "Peoria, IL",
+			"zip":  5,
+		}),
+	}
+
+	nc := datasource.NewNestedContextReader(readers, time.Now())
 
 	hits := []string{
-		`FILTER name == "Yoda"`,
-		`FILTER name != "yoda"`, // we should be case-sensitive by default
-		`FILTER name = "Yoda"`,  // is equivalent to ==
-		`FILTER "Yoda" == name`,
-		`FILTER name != "Anakin"`,
-		`FILTER first_name != "Anakin"`, // key doesn't exist
-		`FILTER tolower(name) == "yoda"`,
+		`FILTER name == "Yoda"`,           // upper case sensitive name
+		`FILTER name != "yoda"`,           // we should be case-sensitive by default
+		`FILTER name = "Yoda"`,            // is equivalent to ==
+		`FILTER "Yoda" == name`,           // reverse order of identity/value
+		`FILTER name != "Anakin"`,         // negation on missing fields == true
+		`FILTER first_name != "Anakin"`,   // key doesn't exist
+		`FILTER tolower(name) == "yoda"`,  // use functions in evaluation
+		`FILTER FullName == "Yoda, Jedi"`, // use functions on structs in evaluation
+		`FILTER name LIKE "*da"`,          // LIKE
+		`FILTER name NOT LIKE "*kin"`,     // LIKE Negation
+		`FILTER name CONTAINS "od"`,       // Contains
+		`FILTER name NOT CONTAINS "kin"`,  // Contains
+		`FILTER Created < "now-1d"`,       // Date Math
+		`FILTER Updated > "now-2h"`,       // Date Math
 		`FILTER OR (
-			EXISTS name,
-			EXISTS not_a_key,
+			EXISTS name,       -- inline commens
+			EXISTS not_a_key,  -- more inline comments
 		)`,
 		// show that line-breaks serve as expression separators
 		`FILTER OR (
 			EXISTS name
-			EXISTS not_a_key
+			EXISTS not_a_key   -- even if they have inline comments
 		)`,
 		//`FILTER a == "Yoda" AND b == "Peoria, IL" AND c == 5`,
-		`FILTER AND (name == "Yoda", city == "Peoria, IL", zip == 5)`,
+		`FILTER AND (name == "Yoda", city == "Peoria, IL", zip == 5, BankAmount > 50)`,
 		`FILTER AND (zip == 5, "Yoda" == name, OR ( city IN ( "Portland, OR", "New York, NY", "Peoria, IL" ) ) )`,
 		`FILTER OR (
 			EXISTS q, 
@@ -54,14 +103,13 @@ func TestFilterQlVm(t *testing.T) {
 	for _, q := range hits {
 		fs, err := expr.ParseFilterQL(q)
 		assert.Equal(t, nil, err)
-		match, err := NewFilterVm(nil).Matches(e, fs)
+		match, err := NewFilterVm(nil).Matches(nc, fs)
 		assert.Equalf(t, nil, err, "error matching on query %q: %v", q, err)
 		assert.T(t, match, q)
 	}
 
 	misses := []string{
 		`FILTER name == "yoda"`, // casing
-
 		"FILTER OR (false, false, AND (true, false))",
 		`FILTER AND (name == "Yoda", city == "xxx", zip == 5)`,
 	}
@@ -69,7 +117,7 @@ func TestFilterQlVm(t *testing.T) {
 	for _, q := range misses {
 		fs, err := expr.ParseFilterQL(q)
 		assert.Equal(t, nil, err)
-		match, err := NewFilterVm(nil).Matches(e, fs)
+		match, err := NewFilterVm(nil).Matches(nc, fs)
 		assert.Equal(t, nil, err)
 		assert.T(t, !match)
 	}

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -25,12 +25,13 @@ type User struct {
 	HasSession    *bool
 	Roles         []string
 	BankAmount    float64
-	Address       struct {
-		City string
-		Zip  int
-	}
-	Data    json.RawMessage
-	Context u.JsonHelper
+	Address       Address
+	Data          json.RawMessage
+	Context       u.JsonHelper
+}
+type Address struct {
+	City string
+	Zip  int
 }
 
 func (m *User) FullName() string {
@@ -50,6 +51,7 @@ func TestFilterQlVm(t *testing.T) {
 		Updated:       &nminus1,
 		Authenticated: true,
 		HasSession:    &tr,
+		Address:       Address{"Detroit", 55},
 		Roles:         []string{"admin", "api"},
 		BankAmount:    55.5,
 	}
@@ -65,20 +67,21 @@ func TestFilterQlVm(t *testing.T) {
 	nc := datasource.NewNestedContextReader(readers, time.Now())
 
 	hits := []string{
-		`FILTER name == "Yoda"`,           // upper case sensitive name
-		`FILTER name != "yoda"`,           // we should be case-sensitive by default
-		`FILTER name = "Yoda"`,            // is equivalent to ==
-		`FILTER "Yoda" == name`,           // reverse order of identity/value
-		`FILTER name != "Anakin"`,         // negation on missing fields == true
-		`FILTER first_name != "Anakin"`,   // key doesn't exist
-		`FILTER tolower(name) == "yoda"`,  // use functions in evaluation
-		`FILTER FullName == "Yoda, Jedi"`, // use functions on structs in evaluation
-		`FILTER name LIKE "*da"`,          // LIKE
-		`FILTER name NOT LIKE "*kin"`,     // LIKE Negation
-		`FILTER name CONTAINS "od"`,       // Contains
-		`FILTER name NOT CONTAINS "kin"`,  // Contains
-		`FILTER Created < "now-1d"`,       // Date Math
-		`FILTER Updated > "now-2h"`,       // Date Math
+		`FILTER name == "Yoda"`,            // upper case sensitive name
+		`FILTER name != "yoda"`,            // we should be case-sensitive by default
+		`FILTER name = "Yoda"`,             // is equivalent to ==
+		`FILTER "Yoda" == name`,            // reverse order of identity/value
+		`FILTER name != "Anakin"`,          // negation on missing fields == true
+		`FILTER first_name != "Anakin"`,    // key doesn't exist
+		`FILTER tolower(name) == "yoda"`,   // use functions in evaluation
+		`FILTER FullName == "Yoda, Jedi"`,  // use functions on structs in evaluation
+		`FILTER Address.City == "Detroit"`, // traverse struct with path.field
+		`FILTER name LIKE "*da"`,           // LIKE
+		`FILTER name NOT LIKE "*kin"`,      // LIKE Negation
+		`FILTER name CONTAINS "od"`,        // Contains
+		`FILTER name NOT CONTAINS "kin"`,   // Contains
+		`FILTER Created < "now-1d"`,        // Date Math
+		`FILTER Updated > "now-2h"`,        // Date Math
 		`FILTER OR (
 			EXISTS name,       -- inline commens
 			EXISTS not_a_key,  -- more inline comments

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -1,0 +1,117 @@
+package vm
+
+import (
+	"fmt"
+	"testing"
+
+	u "github.com/araddon/gou"
+	"github.com/bmizerany/assert"
+
+	"github.com/araddon/qlbridge/datasource"
+	"github.com/araddon/qlbridge/expr"
+)
+
+var _ = u.EMPTY
+
+func TestFilterQlVm(t *testing.T) {
+	t.Parallel()
+
+	e := datasource.NewContextSimpleNative(map[string]interface{}{
+		"name": "Yoda",
+		"city": "Peoria, IL",
+		"zip":  5,
+	})
+
+	hits := []string{
+		`FILTER name == "Yoda"`,
+		`FILTER name != "yoda"`, // we should be case-sensitive by default
+		`FILTER name = "Yoda"`,  // is equivalent to ==
+		`FILTER "Yoda" == name`,
+		`FILTER name != "Anakin"`,
+		`FILTER first_name != "Anakin"`, // key doesn't exist
+		`FILTER tolower(name) == "yoda"`,
+		`FILTER OR (
+			EXISTS name,
+			EXISTS not_a_key,
+		)`,
+		// show that line-breaks serve as expression separators
+		`FILTER OR (
+			EXISTS name
+			EXISTS not_a_key
+		)`,
+		//`FILTER a == "Yoda" AND b == "Peoria, IL" AND c == 5`,
+		`FILTER AND (name == "Yoda", city == "Peoria, IL", zip == 5)`,
+		`FILTER AND (zip == 5, "Yoda" == name, OR ( city IN ( "Portland, OR", "New York, NY", "Peoria, IL" ) ) )`,
+		`FILTER OR (
+			EXISTS q, 
+			AND ( 
+				zip > 0, 
+				OR ( zip > 10000, zip < 100 ) 
+			), 
+			NOT ( name == "Yoda" ) )`,
+	}
+
+	for _, q := range hits {
+		fs, err := expr.ParseFilterQL(q)
+		assert.Equal(t, nil, err)
+		match, err := NewFilterVm(nil).Matches(e, fs)
+		assert.Equalf(t, nil, err, "error matching on query %q: %v", q, err)
+		assert.T(t, match, q)
+	}
+
+	misses := []string{
+		`FILTER name == "yoda"`, // casing
+
+		"FILTER OR (false, false, AND (true, false))",
+		`FILTER AND (name == "Yoda", city == "xxx", zip == 5)`,
+	}
+
+	for _, q := range misses {
+		fs, err := expr.ParseFilterQL(q)
+		assert.Equal(t, nil, err)
+		match, err := NewFilterVm(nil).Matches(e, fs)
+		assert.Equal(t, nil, err)
+		assert.T(t, !match)
+	}
+}
+
+type includer struct{}
+
+func (includer) Include(name string) (*expr.FilterStatement, error) {
+	if name != "test" {
+		return nil, fmt.Errorf("Expected name 'test' but received: %s", name)
+	}
+	return expr.ParseFilterQL("FILTER AND (x > 5)")
+}
+
+func TestInclude(t *testing.T) {
+	t.Parallel()
+
+	e1 := datasource.NewContextSimpleNative(map[string]interface{}{"x": 6, "y": "1"})
+	e2 := datasource.NewContextSimpleNative(map[string]interface{}{"x": 4, "y": "1"})
+
+	q, err := expr.ParseFilterQL("FILTER AND (x < 9000, INCLUDE test)")
+	assert.Equal(t, nil, err)
+
+	filterVm := NewFilterVm(includer{})
+
+	{
+		match, err := filterVm.Matches(e1, q)
+		assert.Equal(t, nil, err)
+		assert.T(t, match)
+	}
+
+	{
+		match, err := filterVm.Matches(e2, q)
+		assert.Equal(t, nil, err)
+		assert.T(t, !match)
+	}
+
+	// Matches should return an error when the query includes an invalid INCLUDE
+	{
+		q, err := expr.ParseFilterQL("FILTER AND (x < 9000, INCLUDE shouldfail)")
+		assert.Equal(t, nil, err)
+		_, err = filterVm.Matches(e1, q)
+		assert.NotEqual(t, nil, err)
+	}
+}


### PR DESCRIPTION
* add support for Eval() vm evaluator for the filterql dialect
* add new context-wrapper for using structs and go datastructures natively in vm https://github.com/araddon/qlbridge/pull/54/files#diff-ede89b0661900aa4393ad19f2f6c04f8R77
* changed behavior of `replace()` expression to be more like every other replace in the world
* datemath
* add new ContextSimpleNative() for use with native go maps

One aspect of this api i don't like is the lack of name-spacing.  Assuming all context objects get flattened into a single keyspace.  Also, this makes finding context for where to operate function on more difficult.