### PR TITLE
expr improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v 0.10  December 2015
 
+* https://github.com/araddon/qlbridge/pull/61
+  *  convert `IN` statement from MultiArg -> BinaryNode w ArrayNode type
+  * cleanup remove un-used interface methods (NodeType())
+  * fingerprint() for filterql
+  * fix negateable string for BinaryNode  (LIKE)
+
 * https://github.com/araddon/qlbridge/pull/54
   - implmennt `FilterQL` in vm.  filterQL is a `WHERE` filter language with dsl nesting
   - context-wrapper, allow go structs to be used natively in vm including functions

--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -33,7 +33,8 @@ func parseFilterQlTest(t *testing.T, ql string) {
 func TestFilterQlRoundTrip(t *testing.T) {
 	t.Parallel()
 
-	parseFilterQlTest(t, `FILTER "bob@gmail.com" IN ("hello")`)
+	parseFilterQlTest(t, `FILTER "bob@gmail.com" IN ("hello","world")`)
+
 	parseFilterQlTest(t, `FILTER "bob@gmail.com" IN identityname`)
 
 	parseFilterQlTest(t, `FILTER email CONTAINS "gmail.com"`)

--- a/expr/parse_filterql_test.go
+++ b/expr/parse_filterql_test.go
@@ -85,6 +85,14 @@ func TestFilterQlRoundTrip(t *testing.T) {
 	`)
 }
 
+func TestFilterQlFingerPrint(t *testing.T) {
+	t.Parallel()
+
+	req1, _ := ParseFilterQL(`FILTER visit_ct > 74`)
+	req2, _ := ParseFilterQL(`FILTER visit_ct > 101`)
+	assert.T(t, req1.FingerPrintID() == req2.FingerPrintID())
+}
+
 func TestFilterQLAstCheck(t *testing.T) {
 	t.Parallel()
 	ql := `

--- a/expr/parse_sql_test.go
+++ b/expr/parse_sql_test.go
@@ -274,9 +274,7 @@ func TestSqlParseAstCheck(t *testing.T) {
 	sel, ok = req.(*SqlSelect)
 	assert.Tf(t, ok, "is SqlSelect: %T", req)
 	assert.Tf(t, len(sel.From) == 1, "has 1 from: %v", sel.From)
-	assert.Tf(t, sel.Where != nil && sel.Where.NodeType() == SqlWhereNodeType, "has sub-select: %v", sel.Where)
-	u.Infof("sel:  %#v", sel.Where)
-
+	assert.Tf(t, sel.Where != nil && sel.Where.Source != nil, "has sub-select: %v", sel.Where)
 }
 
 func TestSqlParseFromTypes(t *testing.T) {
@@ -326,7 +324,6 @@ func TestSqlParseFromTypes(t *testing.T) {
 	assert.Tf(t, len(sel.From) == 3, "has 3 from: %v", sel.From)
 	//assert.Tf(t, len(sel.OrderBy) == 1, "want 1 orderby but has %v", len(sel.OrderBy))
 	u.Info(sel.String())
-
 }
 
 func TestSqlShowAst(t *testing.T) {

--- a/value/value.go
+++ b/value/value.go
@@ -490,7 +490,6 @@ func (m StringsValue) NumberValue() NumberValue {
 			return NewNumberValue(fv)
 		}
 	}
-
 	return NumberNaNValue
 }
 func (m StringsValue) IntValue() IntValue {
@@ -530,8 +529,6 @@ func (m ByteSliceValue) Val() []byte                  { return m.v }
 func (m ByteSliceValue) ToString() string             { return string(m.v) }
 func (m ByteSliceValue) MarshalJSON() ([]byte, error) { return json.Marshal(m.v) }
 func (m ByteSliceValue) Len() int                     { return len(m.v) }
-
-//func (m *ByteSliceValue) Append(v []byte)              { m.v = append(m.v, v...) }
 
 func NewSliceValues(v []Value) SliceValue {
 	return SliceValue{v: v, rv: reflect.ValueOf(v)}


### PR DESCRIPTION
closes #60 

*  convert `IN` statement from MultiArg -> BinaryNode w ArrayNode type
* cleanup remove un-used interface methods (NodeType())
* fingerprint() for filterql
* fix negateable string for BinaryNode  (LIKE)
