### PR TITLE
Support func registry for namespace/context specific funcs

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -39,8 +39,9 @@ type SchemaInfo interface {
 }
 
 // SchemaInfoString implements schemaInfo Key()
-type SchemaInfoString string 
-func (m SchemaInfoString) Key() string { return string(m)}
+type SchemaInfoString string
+
+func (m SchemaInfoString) Key() string { return string(m) }
 
 // TokenPager is responsible for determining end of
 // current tree (column, etc)
@@ -135,10 +136,15 @@ type Tree struct {
 	runCheck   bool
 	Root       Node // top-level root node of the tree
 	TokenPager      // pager for grabbing next tokens, backup(), recognizing end
+	fr         FuncResolver
 }
 
 func NewTree(pager TokenPager) *Tree {
 	t := Tree{TokenPager: pager}
+	return &t
+}
+func NewTreeFuncs(pager TokenPager, fr FuncResolver) *Tree {
+	t := Tree{TokenPager: pager, fr: fr}
 	return &t
 }
 
@@ -692,19 +698,22 @@ func (t *Tree) Func(depth int, funcTok lex.Token) (fn *FuncNode) {
 			t.Next()
 		}
 	}
-
-	return fn
 }
 
 // get Function from Global
 func (t *Tree) getFunction(name string) (v Func, ok bool) {
+	if t.fr != nil {
+		if v, ok = t.fr.FuncGet(name); ok {
+			return
+		}
+	}
 	if v, ok = funcs[strings.ToLower(name)]; ok {
 		return
 	}
 	return
 }
 
-// Value arrays are:
+// ValueArray
 //     IN ("a","b","c")
 //     ["a","b","c"]
 func ValueArray(pg TokenPager) (value.Value, error) {

--- a/plan/context.go
+++ b/plan/context.go
@@ -47,6 +47,7 @@ type Context struct {
 	// Local in-memory helpers not transported across network
 	Session expr.ContextReadWriter // Session for this connection
 	Schema  *schema.Schema         // this schema for this connection
+	Funcs   expr.FuncResolver      // Local/Dialect specific functions
 
 	// From configuration
 	DisableRecover bool
@@ -56,7 +57,7 @@ type Context struct {
 	errRecover interface{}
 }
 
-// New plan context
+// NewContext plan context
 func NewContext(query string) *Context {
 	return &Context{Raw: query}
 }

--- a/rel/parse_filterql.go
+++ b/rel/parse_filterql.go
@@ -129,7 +129,7 @@ func (m *filterQLParser) parseSelect() (*FilterSelect, error) {
 	req.Description = m.comment
 	m.Next() // Consume Select
 
-	if err := parseColumns(m, m.buildVm, req); err != nil {
+	if err := parseColumns(m, nil, m.buildVm, req); err != nil {
 		u.Debug(err)
 		return nil, err
 	}


### PR DESCRIPTION
In need of supporting dialect (mysql) specific type-writers ("string" = "varchar", "string" = "text") support function registry that kills 2 birds with one stone:

* support namespacing, and context specific functions
* use this to allow mysql, other dialects to implement their own type-writer