### PR TITLE
Make fallback Value type for Go values Struct

### DIFF
--- a/value/value.go
+++ b/value/value.go
@@ -275,7 +275,9 @@ func ValueFromString(vt string) ValueType {
 	}
 }
 
-// Create a new Value type with native go value
+// NewValue creates a new Value type from a native Go value.
+//
+// Defaults to StructValue for unknown types.
 func NewValue(goVal interface{}) Value {
 
 	switch val := goVal.(type) {
@@ -332,13 +334,8 @@ func NewValue(goVal interface{}) Value {
 		}
 		return NewSliceValues(vals)
 	default:
-		if valValue, ok := goVal.(Value); ok {
-			return valValue
-		}
-		u.LogTracef(u.WARN, "hello")
-		u.Errorf("invalud value type %T.", val)
+		return NewStructValue(val)
 	}
-	return NilValueVal
 }
 
 func NewValueReflect(rv reflect.Value) Value {

--- a/value/value_test.go
+++ b/value/value_test.go
@@ -1,0 +1,43 @@
+package value_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/araddon/qlbridge/value"
+)
+
+// TestNewValue tests the conversion from Go types to Values.
+func TestNewValue(t *testing.T) {
+	v := NewValue(int(1))
+	if _, ok := v.(IntValue); !ok {
+		t.Errorf("Expected IntValue but received %T", v)
+	}
+
+	v = NewValue(float64(1.0))
+	if _, ok := v.(NumberValue); !ok {
+		t.Errorf("Expected NumberValue but received %T", v)
+	}
+
+	v = NewValue(true)
+	if v, ok := v.(BoolValue); !ok {
+		t.Errorf("Expected BoolValue but received %T", v)
+	}
+
+	v = NewValue(map[string]bool{"foo": false})
+	if _, ok := v.(MapBoolValue); !ok {
+		t.Errorf("Expected MapBoolValue but received %T", v)
+	}
+
+	// Make sure an unknown type is converted to a StructValue
+	v = NewValue(struct{ Foo string }{})
+	if _, ok := v.(StructValue); !ok {
+		t.Errorf("Expected StructValue but received %T", v)
+	}
+
+	// Make sure Values are just roundtripped
+	v2 := NewTimeValue(time.Now())
+	if v3 := NewValue(v2); v2 != v3 {
+		t.Errorf("Expected %T but received %T", v2, v3)
+	}
+}


### PR DESCRIPTION
Previously NewValue would return the NilValueVal for unknown Go types.
StructValues are created specifically to be opaque wrappers around
Go types, so I thought it made more sense to return that instead.

I could use reflect to ensure the Go value is a struct, but I wanted to
avoid using reflect unless absolutely neccessary.