### PR TITLE
Filter() func, switch to info-schema in  executor

### DIFF
--- a/datasource/schemadb.go
+++ b/datasource/schemadb.go
@@ -68,6 +68,7 @@ func (m *SchemaDb) Close() error     { return nil }
 func (m *SchemaDb) Tables() []string { return m.tbls }
 func (m *SchemaDb) Table(table string) (*schema.Table, error) {
 
+	//u.Debugf("Table(%q)", table)
 	switch table {
 	case "tables":
 		return m.tableForTables()
@@ -83,6 +84,7 @@ func (m *SchemaDb) Table(table string) (*schema.Table, error) {
 
 // Create a SchemaSource specific to schema object (table, database)
 func (m *SchemaDb) Open(schemaObjectName string) (schema.Conn, error) {
+
 	//u.Debugf("SchemaDb.Open(%q)", schemaObjectName)
 	//u.WarnT(8)
 	tbl, err := m.Table(schemaObjectName)

--- a/datasource/schemadb_test.go
+++ b/datasource/schemadb_test.go
@@ -100,8 +100,10 @@ func TestSchemaShowStatements(t *testing.T) {
 		},
 	)
 	// VARIABLES
-	testutil.TestSelect(t, `show global variables like '*packet';`,
-		[][]driver.Value{{"@@max_allowed_packet", int64(datasource.MaxAllowedPacket)}},
+	testutil.TestSelect(t, `show global variables like 'max_allowed*';`,
+		[][]driver.Value{
+			{"max_allowed_packet", int64(datasource.MaxAllowedPacket)},
+		},
 	)
 
 	// DESCRIBE

--- a/datasource/session.go
+++ b/datasource/session.go
@@ -43,6 +43,7 @@ func NewMySqlGlobalVars() *ContextSimple {
 	ctx := NewContextSimple()
 
 	ctx.Data["@@session.auto_increment_increment"] = value.NewIntValue(1)
+	ctx.Data["auto_increment_increment"] = value.NewIntValue(1)
 	ctx.Data["@@session.tx_read_only"] = value.NewIntValue(1)
 	//ctx.Data["@@session.auto_increment_increment"] = value.NewBoolValue(true)
 	ctx.Data["@@character_set_client"] = value.NewStringValue("utf8")
@@ -53,6 +54,7 @@ func NewMySqlGlobalVars() *ContextSimple {
 	ctx.Data["@@interactive_timeout"] = value.NewIntValue(28800)
 	ctx.Data["@@license"] = value.NewStringValue("MIT")
 	ctx.Data["@@lower_case_table_names"] = value.NewIntValue(0)
+	ctx.Data["max_allowed_packet"] = value.NewIntValue(MaxAllowedPacket)
 	ctx.Data["@@max_allowed_packet"] = value.NewIntValue(MaxAllowedPacket)
 	ctx.Data["@@max_allowed_packets"] = value.NewIntValue(MaxAllowedPacket)
 	ctx.Data["@@net_buffer_length"] = value.NewIntValue(16384)

--- a/datasource/sourceregistry.go
+++ b/datasource/sourceregistry.go
@@ -288,9 +288,6 @@ func loadSystemSchema(ss *schema.SchemaSource) error {
 		return fmt.Errorf("Must have schema but was nil")
 	}
 
-	//u.WarnT(6)
-	//u.Debugf("loadSystemSchema")
-
 	infoSchema := s.InfoSchema
 	var infoSchemaSource *schema.SchemaSource
 	if infoSchema == nil {
@@ -306,6 +303,7 @@ func loadSystemSchema(ss *schema.SchemaSource) error {
 		infoSchemaSource.Schema = infoSchema
 		infoSchemaSource.AddTableName("tables")
 		infoSchema.SchemaSources["schema"] = infoSchemaSource
+		infoSchema.InfoSchema = infoSchema
 	} else {
 		infoSchemaSource = infoSchema.SchemaSources["schema"]
 	}

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -158,6 +158,10 @@ var builtinTests = []testBuiltins{
 	{`match("score_","tag_")`, value.NewMapValue(map[string]interface{}{"amount": "22", "name": "bob"})},
 	{`match("nonfield_")`, value.ErrValue},
 
+	{`filter(match("score_","tag_"),"nam*")`, value.NewMapValue(map[string]interface{}{"amount": "22"})},
+	{`filter(match("score_","tag_"),"name")`, value.NewMapValue(map[string]interface{}{"amount": "22"})},
+	{`filter(split("apples,oranges",","),"ora*")`, value.NewStringsValue([]string{"apples"})},
+
 	{`email("Bob@Bob.com")`, value.NewStringValue("bob@bob.com")},
 	{`email("Bob <bob>")`, value.ErrValue},
 	{`email("Bob <bob@bob.com>")`, value.NewStringValue("bob@bob.com")},

--- a/plan/planner_select.go
+++ b/plan/planner_select.go
@@ -15,12 +15,9 @@ func (m *PlannerDefault) WalkPreparedStatement(p *PreparedStatement) error {
 
 func (m *PlannerDefault) WalkSelect(p *Select) error {
 
-	//u.Debugf("VisitSelect %+v", p.Stmt)
+	//u.Debugf("VisitSelect ctx:%p  %+v", p.Ctx, p.Stmt)
 
 	needsFinalProject := true
-
-	//if p.Stmt.SystemQry() {
-	//		return m.WalkSelectSystemInfo(p)
 
 	if len(p.Stmt.From) == 0 {
 
@@ -183,8 +180,17 @@ func (m *PlannerDefault) WalkSourceSelect(p *Source) error {
 			return err
 		}
 		if p.Conn == nil {
-			u.Warnf("hm  no conn....")
-			return nil
+			if p.Stmt != nil {
+				if p.Stmt.IsLiteral() {
+					// this is fine
+				} else {
+					u.Warnf("no data source and not literal query? %s", p.Stmt.String())
+					return ErrNoDataSource
+				}
+			} else {
+				u.Warnf("hm  no conn, no stmt?....")
+				return ErrNoDataSource
+			}
 		}
 	}
 

--- a/rel/parse_sql.go
+++ b/rel/parse_sql.go
@@ -1040,6 +1040,7 @@ func (m *Sqlbridge) parseSourceSubQuery(src *SqlSource) error {
 }
 
 func (m *Sqlbridge) parseSourceTable(req *SqlSelect) error {
+
 	if m.Cur().T != lex.TokenIdentity {
 		return fmt.Errorf("expected tablename but got: %v", m.Cur())
 	}

--- a/rel/parse_sql_test.go
+++ b/rel/parse_sql_test.go
@@ -201,6 +201,7 @@ func TestSqlParseAstCheck(t *testing.T) {
 	assert.Tf(t, err == nil && req != nil, "Must parse: %s  \n\t%v", sql, err)
 	sel, ok = req.(*SqlSelect)
 	assert.Tf(t, ok, "is SqlSelect: %T", req)
+	assert.Tf(t, sel.IsLiteral(), "Should be literal? %v", sql)
 	assert.Tf(t, sel.Limit == 7, "has limit = 7: %v", sel.Limit)
 	assert.Tf(t, len(sel.Columns) == 1, "has 1 col: %v", len(sel.Columns))
 	assert.Tf(t, sel.Columns[0].As == "@@version_comment", "")

--- a/rel/sql.go
+++ b/rel/sql.go
@@ -830,6 +830,7 @@ func (m *PreparedStatement) FingerPrint(r rune) string {
 func (m *SqlSelect) Keyword() lex.TokenType { return lex.TokenSelect }
 func (m *SqlSelect) SystemQry() bool        { return len(m.From) == 0 && m.schemaqry }
 func (m *SqlSelect) SetSystemQry()          { m.schemaqry = true }
+func (m *SqlSelect) IsLiteral() bool        { return len(m.From) == 0 }
 func (m *SqlSelect) FromPB(spb *SqlSelectPb) *SqlSelect {
 	return SqlSelectFromPb(spb)
 }
@@ -1227,6 +1228,7 @@ func (m *SqlSelect) Rewrite() {
 	}
 }
 
+func (m *SqlSource) IsLiteral() bool        { return len(m.Name) == 0 }
 func (m *SqlSource) Keyword() lex.TokenType { return m.Op }
 func (m *SqlSource) SourceName() string {
 	if m == nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -533,7 +533,7 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool)
 			case value.StringValue:
 				// [x,y,z] LIKE str
 				for _, val := range at.Val() {
-					if boolVal, ok := likeCompare(val.ToString(), bv.Val()); ok && boolVal.Val() == true {
+					if boolVal, ok := LikeCompare(val.ToString(), bv.Val()); ok && boolVal.Val() == true {
 						return boolVal, true
 					}
 				}
@@ -584,7 +584,7 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode) (value.Value, bool)
 			case value.StringValue:
 				// [x,y,z] LIKE str
 				for _, val := range at.Val() {
-					boolVal, ok := likeCompare(val, bv.Val())
+					boolVal, ok := LikeCompare(val, bv.Val())
 					//u.Debugf("%s like %s ?? ok?%v  result=%v", val, bv.Val(), ok, boolVal)
 					if ok && boolVal.Val() == true {
 						return boolVal, true
@@ -1060,7 +1060,7 @@ func operateStrings(op lex.Token, av, bv value.StringValue) value.Value {
 		}
 		return value.BoolValueFalse
 	case lex.TokenLike: // a(value) LIKE b(pattern)
-		bv, ok := likeCompare(a, b)
+		bv, ok := LikeCompare(a, b)
 		if !ok {
 			return value.NewErrorValuef("invalid LIKE pattern: %q", a)
 		}
@@ -1074,7 +1074,7 @@ func operateStrings(op lex.Token, av, bv value.StringValue) value.Value {
 	return value.NewErrorValuef("unsupported operator for strings: %s", op.T)
 }
 
-func likeCompare(a, b string) (value.BoolValue, bool) {
+func LikeCompare(a, b string) (value.BoolValue, bool) {
 	// Do we want to always do this replacement?   Or do this at parse time or config?
 	if strings.Contains(b, "%") {
 		b = strings.Replace(b, "%", "*", -1)


### PR DESCRIPTION
* new `Filter()` func
* for fully qualified `schema`.`table` queries switch to `schema` instead of one in use