### PR TITLE
Schema improvements

### DIFF
--- a/exec/groupby.go
+++ b/exec/groupby.go
@@ -449,11 +449,13 @@ colLoop:
 			case "sum":
 				aggs[colIdx] = NewSum(col, p.Partial)
 			default:
-				return nil, fmt.Errorf("Not impelemneted groupby for column: %s", col.Expr)
+				return nil, fmt.Errorf("Not implemented groupby for column: %s", col.Expr)
 			}
 		case *expr.BinaryNode:
 			// binary logic?
-			return nil, fmt.Errorf("Not impelemneted groupby for column: %s", col.Expr)
+			return nil, fmt.Errorf("Not implemented groupby for column: %s", col.Expr)
+		default:
+			return nil, fmt.Errorf("Not implemented groupby for column: %s", col.Expr)
 		}
 	}
 	return aggs, nil

--- a/lex/dialect_sql.go
+++ b/lex/dialect_sql.go
@@ -166,6 +166,9 @@ var SqlSet = []*Clause{
 var SqlUse = []*Clause{
 	{Token: TokenUse, Lexer: LexIdentifier},
 }
+var SqlRollback = []*Clause{
+	{Token: TokenRollback, Lexer: LexEmpty},
+}
 
 // SqlDialect is a SQL like dialect
 //
@@ -200,6 +203,7 @@ var SqlDialect *Dialect = &Dialect{
 		&Clause{Token: TokenShow, Clauses: SqlShow},
 		&Clause{Token: TokenSet, Clauses: SqlSet},
 		&Clause{Token: TokenUse, Clauses: SqlUse},
+		&Clause{Token: TokenRollback, Clauses: SqlRollback},
 	},
 }
 

--- a/lex/dialect_sql.go
+++ b/lex/dialect_sql.go
@@ -169,6 +169,9 @@ var SqlUse = []*Clause{
 var SqlRollback = []*Clause{
 	{Token: TokenRollback, Lexer: LexEmpty},
 }
+var SqlCommit = []*Clause{
+	{Token: TokenCommit, Lexer: LexEmpty},
+}
 
 // SqlDialect is a SQL like dialect
 //
@@ -204,6 +207,7 @@ var SqlDialect *Dialect = &Dialect{
 		&Clause{Token: TokenSet, Clauses: SqlSet},
 		&Clause{Token: TokenUse, Clauses: SqlUse},
 		&Clause{Token: TokenRollback, Clauses: SqlRollback},
+		&Clause{Token: TokenCommit, Clauses: SqlCommit},
 	},
 }
 

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -3212,7 +3212,11 @@ func scanNumericOrDuration(l *Lexer, doDuration bool) (typ TokenType, ok bool) {
 	// Optional leading sign.
 	hasSign := l.accept("+-")
 	peek2 := l.PeekX(2)
-	//u.Debugf("scanNumericOrDuration?  '%v'", string(peek2))
+	peek2nd := byte(0)
+	if len(peek2) == 2 {
+		peek2nd = peek2[1]
+	}
+	//u.Debugf("scanNumericOrDuration?  '%v' peek:%v ", string(peek2), len(peek2))
 	if peek2 == "0x" {
 		// Hexadecimal.
 		if hasSign {
@@ -3244,8 +3248,8 @@ func scanNumericOrDuration(l *Lexer, doDuration bool) (typ TokenType, ok bool) {
 		} else {
 			if (!hasSign && l.input[l.start] == '0') ||
 				(hasSign && l.input[l.start+1] == '0') {
-				switch peek2[1] {
-				case ' ', '\t', '\n', ',', ')', ';':
+				switch peek2nd {
+				case ' ', '\t', '\n', ',', ')', ';', byte(0):
 					return typ, true
 				}
 				// Integers can't start with 0??

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -485,7 +485,7 @@ func (l *Lexer) ReverseTrim() {
 // expects matchTo to be a lower case string
 func (l *Lexer) match(matchTo string, skip int) bool {
 
-	//u.Debugf("match() : %v", matchTo)
+	//u.Debugf("match(%q)  peek:%q ", matchTo, l.PeekWord())
 	for _, matchRune := range matchTo {
 		//u.Debugf("match rune? %v", string(matchRune))
 		if skip > 0 {
@@ -499,6 +499,9 @@ func (l *Lexer) match(matchTo string, skip int) bool {
 			//u.Debugf("setting done = false?, ie did not match")
 			return false
 		}
+	}
+	if l.IsEnd() {
+		return true
 	}
 	// If we finished looking for the match word, and the next item is not
 	// whitespace, it means we failed
@@ -700,7 +703,7 @@ func LexMatchClosure(tok TokenType, nextFn StateFn) StateFn {
 	return func(l *Lexer) StateFn {
 		//u.Debugf("%p lexMatch   t=%s peek=%s", l, tok, l.PeekWord())
 		if l.match(tok.String(), 0) {
-			//u.Debugf("found match: %s   %v", tok, fn)
+			//u.Debugf("found match: %s   %v", tok, nextFn)
 			l.Emit(tok)
 			return nextFn
 		}

--- a/lex/token.go
+++ b/lex/token.go
@@ -138,6 +138,7 @@ const (
 	TokenDescribe  TokenType = 211 // We can also use TokenDesc
 	TokenExplain   TokenType = 212 // another alias for desccribe
 	TokenReplace   TokenType = 213 // Insert/Replace are interchangeable on insert statements
+	TokenRollback  TokenType = 214
 
 	// Other QL Keywords, These are clause-level keywords that mark seperation between clauses
 	TokenTable    TokenType = 301 // table
@@ -302,6 +303,7 @@ var (
 		TokenDescribe:  {Description: "describe"},
 		TokenExplain:   {Description: "explain"},
 		TokenReplace:   {Description: "replace"},
+		TokenRollback:  {Description: "rollback"},
 
 		// Top Level ql clause keywords
 		TokenTable:   {Description: "table"},

--- a/lex/token.go
+++ b/lex/token.go
@@ -139,6 +139,7 @@ const (
 	TokenExplain   TokenType = 212 // another alias for desccribe
 	TokenReplace   TokenType = 213 // Insert/Replace are interchangeable on insert statements
 	TokenRollback  TokenType = 214
+	TokenCommit    TokenType = 215
 
 	// Other QL Keywords, These are clause-level keywords that mark seperation between clauses
 	TokenTable    TokenType = 301 // table
@@ -304,6 +305,7 @@ var (
 		TokenExplain:   {Description: "explain"},
 		TokenReplace:   {Description: "replace"},
 		TokenRollback:  {Description: "rollback"},
+		TokenCommit:    {Description: "commit"},
 
 		// Top Level ql clause keywords
 		TokenTable:   {Description: "table"},

--- a/plan/planner_select.go
+++ b/plan/planner_select.go
@@ -15,7 +15,7 @@ func (m *PlannerDefault) WalkPreparedStatement(p *PreparedStatement) error {
 
 func (m *PlannerDefault) WalkSelect(p *Select) error {
 
-	//u.Debugf("VisitSelect ctx:%p  %+v", p.Ctx, p.Stmt)
+	u.Debugf("VisitSelect ctx:%p  %+v", p.Ctx, p.Stmt)
 
 	needsFinalProject := true
 

--- a/plan/planner_select.go
+++ b/plan/planner_select.go
@@ -15,7 +15,7 @@ func (m *PlannerDefault) WalkPreparedStatement(p *PreparedStatement) error {
 
 func (m *PlannerDefault) WalkSelect(p *Select) error {
 
-	u.Debugf("VisitSelect ctx:%p  %+v", p.Ctx, p.Stmt)
+	//u.Debugf("VisitSelect ctx:%p  %+v", p.Ctx, p.Stmt)
 
 	needsFinalProject := true
 

--- a/plan/projection.go
+++ b/plan/projection.go
@@ -7,6 +7,7 @@ import (
 
 	u "github.com/araddon/gou"
 
+	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/rel"
 	"github.com/araddon/qlbridge/value"
 )
@@ -55,12 +56,25 @@ func (m *Projection) loadLiteralProjection(ctx *Context) error {
 		if col.Expr == nil {
 			return fmt.Errorf("no column info? %#v", col.Expr)
 		}
-		//u.Debugf("col.As=%q  col %#v", col.As, col)
+		//u.Debugf("col.As=%q  col.Expr %#v", col.As, col.Expr)
+		as := col.As
 		if col.As == "" {
-			proj.AddColumnShort(col.Expr.String(), value.StringType)
-		} else {
-			proj.AddColumnShort(col.As, value.StringType)
+			as = col.Expr.String()
 		}
+		switch et := col.Expr.(type) {
+		case *expr.NumberNode:
+			// number?
+			if et.IsInt {
+				proj.AddColumnShort(as, value.IntType)
+			} else {
+				proj.AddColumnShort(as, value.NumberType)
+			}
+			//u.Infof("number? %#v", et)
+		default:
+			//u.Infof("type? %#v", et)
+			proj.AddColumnShort(as, value.StringType)
+		}
+
 	}
 
 	ctx.Projection = NewProjectionStatic(proj)

--- a/plan/sql_rewrite.go
+++ b/plan/sql_rewrite.go
@@ -100,13 +100,22 @@ func RewriteShowAsSelect(stmt *rel.SqlShow, ctx *Context) (*rel.SqlSelect, error
 		}
 	case "keys", "indexes", "index":
 		/*
-			mysql> show keys from user;
+			mysql> show keys from `user` from `mysql`;
 			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
 			| Table | Non_unique | Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
 			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
 			| user  |          0 | PRIMARY  |            1 | Host        | A         |        NULL |     NULL | NULL   |      | BTREE      |         |               |
-			| user  |          0 | PRIMARY  |            2 | User        | A         |           7 |     NULL | NULL   |      | BTREE      |         |               |
+			| user  |          0 | PRIMARY  |            2 | User        | A         |           3 |     NULL | NULL   |      | BTREE      |         |               |
 			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+
+			mysql> show indexes from `user` from `mysql`;
+			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+			| Table | Non_unique | Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+			| user  |          0 | PRIMARY  |            1 | Host        | A         |        NULL |     NULL | NULL   |      | BTREE      |         |               |
+			| user  |          0 | PRIMARY  |            2 | User        | A         |           3 |     NULL | NULL   |      | BTREE      |         |               |
+			+-------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
+
 		*/
 		sqlStatement = fmt.Sprintf("select Table, Non_unique, Key_name, Seq_in_index, Column_name, Collation, Cardinality, Sub_part, Packed, `Null`, Index_type, Index_comment from `schema`.`indexes`;")
 

--- a/rel/parse_sql.go
+++ b/rel/parse_sql.go
@@ -105,6 +105,8 @@ func (m *Sqlbridge) parse() (SqlStatement, error) {
 		return m.parseDescribe()
 	case lex.TokenSet, lex.TokenUse:
 		return m.parseCommand()
+	case lex.TokenRollback:
+		return m.parseTransaction()
 	}
 	u.Warnf("Could not parse?  %v   peek=%v", m.l.RawInput(), m.l.PeekX(40))
 	return nil, fmt.Errorf("Unrecognized request type: %v", m.l.PeekWord())
@@ -687,6 +689,17 @@ func (m *Sqlbridge) parseCommand() (*SqlCommand, error) {
 		return req, nil
 	}
 	return req, m.parseCommandColumns(req)
+}
+
+func (m *Sqlbridge) parseTransaction() (*SqlCommand, error) {
+
+	/*
+		- rollback
+	*/
+	req := &SqlCommand{Columns: make(CommandColumns, 0)}
+	req.kw = m.Next().T // rollback?
+
+	return req, nil
 }
 
 func parseColumns(m expr.TokenPager, fr expr.FuncResolver, buildVm bool, stmt ColumnsStatement) error {

--- a/rel/parse_sql.go
+++ b/rel/parse_sql.go
@@ -579,7 +579,7 @@ func (m *Sqlbridge) parseShow() (*SqlShow, error) {
 	case "databases":
 		req.ShowType = "databases"
 		m.Next()
-	case "indexes":
+	case "indexes", "keys":
 		req.ShowType = "indexes"
 		m.Next()
 	case "variables":

--- a/rel/parse_sql.go
+++ b/rel/parse_sql.go
@@ -1557,12 +1557,13 @@ func (m *Sqlbridge) parseLimit(req *SqlSelect) error {
 	if m.Cur().T != lex.TokenInteger {
 		return fmt.Errorf("Limit must be an integer %v %v", m.Cur().T, m.Cur().V)
 	}
-	iv, err := strconv.Atoi(m.Cur().V)
-	m.Next()
+	limval := m.Next()
+	iv, err := strconv.Atoi(limval.V)
 	if err != nil {
-		return fmt.Errorf("Could not convert limit to integer %v", m.Cur().V)
+		return fmt.Errorf("Could not convert limit to integer %v", limval)
 	}
 	req.Limit = int(iv)
+	//u.Infof("limit clause: %v  peek:%v", limval, m.l.PeekX(20))
 	switch m.Cur().T {
 	case lex.TokenComma:
 		// LIMIT 0, 1000

--- a/rel/parse_sql_test.go
+++ b/rel/parse_sql_test.go
@@ -125,6 +125,8 @@ func TestSqlLexOnly(t *testing.T) {
 	parseSqlTest(t, "SHOW FULL COLUMNS FROM `tablex` FROM `dbx` LIKE '%';")
 	parseSqlTest(t, `SHOW VARIABLES`)
 	parseSqlTest(t, `SHOW GLOBAL VARIABLES like '%'`)
+	parseSqlTest(t, "show keys from `appearances` from `baseball`")
+	parseSqlTest(t, "show indexes from `appearances` from `baseball`")
 	//parseSqlTest(t, `SHOW VARIABLES where `)
 
 	parseSqlTest(t, `select *, @@var_name from movies`)

--- a/rel/parse_sql_test.go
+++ b/rel/parse_sql_test.go
@@ -119,6 +119,7 @@ func TestSqlLexOnly(t *testing.T) {
 	parseSqlTest(t, `SELECT DATABASE()`)
 	parseSqlTest(t, `select @@version_comment limit 1`)
 
+	parseSqlTest(t, `rollback`)
 	parseSqlTest(t, `DESCRIBE mytable`)
 	parseSqlTest(t, `show tables`)
 	parseSqlTest(t, `show tables LIKE "user%";`)

--- a/rel/parse_sql_test.go
+++ b/rel/parse_sql_test.go
@@ -55,6 +55,7 @@ func TestSqlLexOnly(t *testing.T) {
 	parseSqlTest(t, "SELECT COUNT(*) AS count FROM providers WHERE (`providers._id` != NULL)")
 
 	parseSqlTest(t, "select title from article WITH distributed=true, node_ct=10")
+	parseSqlTest(t, "SELECT `appearances`.`G_ph` AS `field` FROM `appearances` ORDER BY `appearances`.`G_ph` ASC LIMIT 500 OFFSET 0")
 
 	parseSqlTest(t, `
 		select  @@session.auto_increment_increment as auto_increment_increment, 

--- a/rel/sql.go
+++ b/rel/sql.go
@@ -200,11 +200,11 @@ type (
 		Tok      lex.Token // Explain, Describe, Desc
 		Stmt     SqlStatement
 	}
-	// SQL INTO statement   (select a,b,c from y INTO z)
+	// SqlInto   INTO statement   (select a,b,c from y INTO z)
 	SqlInto struct {
 		Table string
 	}
-	// Sql Command is admin command such as "SET", "USE"
+	// SqlCommand is admin command such as "SET", "USE"
 	SqlCommand struct {
 		kw       lex.TokenType  // SET or USE
 		Columns  CommandColumns // can have multiple columns in command


### PR DESCRIPTION
* support the `keys & indexes` schema queries (empty results, but don't blow up)
* lex, parse `rollback, commit` transaction messages
* bug in lexer for LIMIT clause