### PR TITLE
Custom quote marks on string values that vary by dialect

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,7 +1,7 @@
 github.com/araddon/dateparse a19b713c2e31cec89903deb95b4d053e9e7b4db5
 github.com/araddon/gou 50a94aa4a3fb69e8fbde05df290fcb49fa685e07
 github.com/bmizerany/assert b7ed37b82869576c289d7d97fb2bbd8b64a0cb28
-github.com/dataux/dataux 41957eabc4576b693c46f7ceda5e6302a0171b7c
+github.com/dataux/dataux 42a8f703aef2deb5e3696c2f5353ac4c33c48ab6
 github.com/dchest/siphash 6d8617816bb5d8268011ffbfb8720f17ce9af63c
 github.com/go-sql-driver/mysql 3654d25ec346ee8ce71a68431025458d52a38ac0
 github.com/gogo/protobuf 2752d97bbd91927dd1c43296dbf8700e50e2708c

--- a/exec/executor.go
+++ b/exec/executor.go
@@ -309,7 +309,7 @@ func (m *JobExecutor) WalkPlanTask(p plan.Task) (Task, error) {
 	panic(fmt.Sprintf("Task plan-exec Not implemented for %T", p))
 }
 
-// WalkChildren walk dag of plan taasks creating execution tasks
+// WalkChildren walk dag of plan tasks creating execution tasks
 func (m *JobExecutor) WalkChildren(p plan.Task, root Task) error {
 	for _, t := range p.Children() {
 		//u.Debugf("parent: %T  walk child %p %T  %#v", p, t, t, p.Children())

--- a/expr/node.pb.go
+++ b/expr/node.pb.go
@@ -114,7 +114,8 @@ func (*ArrayNodePb) ProtoMessage()    {}
 // String literal, no children
 type StringNodePb struct {
 	Noquote          *bool  `protobuf:"varint,1,opt,name=noquote" json:"noquote,omitempty"`
-	Text             string `protobuf:"bytes,2,opt,name=text" json:"text"`
+	Quote            *int32 `protobuf:"varint,2,opt,name=quote" json:"quote,omitempty"`
+	Text             string `protobuf:"bytes,3,opt,name=text" json:"text"`
 	XXX_unrecognized []byte `json:"-"`
 }
 
@@ -503,7 +504,12 @@ func (m *StringNodePb) MarshalTo(data []byte) (int, error) {
 		}
 		i++
 	}
-	data[i] = 0x12
+	if m.Quote != nil {
+		data[i] = 0x10
+		i++
+		i = encodeVarintNode(data, i, uint64(*m.Quote))
+	}
+	data[i] = 0x1a
 	i++
 	i = encodeVarintNode(data, i, uint64(len(m.Text)))
 	i += copy(data[i:], m.Text)
@@ -579,7 +585,7 @@ func (m *NumberNodePb) MarshalTo(data []byte) (int, error) {
 	i = encodeVarintNode(data, i, uint64(m.Iv))
 	data[i] = 0x21
 	i++
-	i = encodeFixed64Node(data, i, uint64(math.Float64bits(m.Fv)))
+	i = encodeFixed64Node(data, i, uint64(math.Float64bits(float64(m.Fv))))
 	data[i] = 0x2a
 	i++
 	i = encodeVarintNode(data, i, uint64(len(m.Text)))
@@ -780,6 +786,9 @@ func (m *StringNodePb) Size() (n int) {
 	_ = l
 	if m.Noquote != nil {
 		n += 2
+	}
+	if m.Quote != nil {
+		n += 1 + sovNode(uint64(*m.Quote))
 	}
 	l = len(m.Text)
 	n += 1 + l + sovNode(uint64(l))
@@ -1828,6 +1837,26 @@ func (m *StringNodePb) Unmarshal(data []byte) error {
 			b := bool(v != 0)
 			m.Noquote = &b
 		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Quote", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowNode
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				v |= (int32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Quote = &v
+		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Text", wireType)
 			}

--- a/expr/node.proto
+++ b/expr/node.proto
@@ -59,7 +59,8 @@ message ArrayNodePb {
 // String literal, no children
 message StringNodePb {
 	optional bool noquote = 1 [(gogoproto.nullable) = true];
-	optional string text = 2 [(gogoproto.nullable) = false];
+	optional int32 quote = 2 [(gogoproto.nullable) = true];
+	optional string text = 3 [(gogoproto.nullable) = false];
 }
 
 // Identity

--- a/expr/node_test.go
+++ b/expr/node_test.go
@@ -14,6 +14,8 @@ var pbTests = []string{
 	`eq(event,"stuff") OR ge(party, 1)`,
 	`"Portland" IN ("ohio")`,
 	`"xyz" BETWEEN todate("1/1/2015") AND 50`,
+	`name == "bob"`,
+	`name = 'bob'`,
 }
 
 func TestNodePb(t *testing.T) {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -516,7 +516,7 @@ func (t *Tree) v(depth int) Node {
 		t.Next()
 		return n
 	case lex.TokenValue:
-		n := NewStringNode(cur.V)
+		n := NewStringNodeToken(cur)
 		t.Next()
 		return n
 	case lex.TokenIdentity:
@@ -609,11 +609,11 @@ func (t *Tree) Func(depth int, funcTok lex.Token) (fn *FuncNode) {
 			t.unexpected(t.Cur(), "func AS")
 		}
 		// This really isn't correct, we probably need an OperatorNode?
-		fn.append(NewStringNode(t.Next().V))
+		fn.append(NewStringNodeToken(t.Next()))
 		if t.Cur().T != lex.TokenIdentity {
 			t.unexpected(t.Cur(), "func AS")
 		}
-		fn.append(NewStringNode(t.Next().V))
+		fn.append(NewStringNodeToken(t.Next()))
 		//u.Debugf("nice %s", fn.String())
 		return fn
 	default:

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -1008,6 +1008,7 @@ func LexValue(l *Lexer) StateFn {
 						l.backup()
 						// for single quote which is not part of the value
 						l.backup()
+						l.lastQuoteMark = byte(firstRune)
 						l.Emit(typ)
 						// now ignore that single quote
 						l.Next()
@@ -1017,6 +1018,7 @@ func LexValue(l *Lexer) StateFn {
 				} else {
 					// at the very end
 					l.backup()
+					l.lastQuoteMark = byte(firstRune)
 					l.Emit(typ)
 					l.Next()
 					return nil

--- a/lex/token.go
+++ b/lex/token.go
@@ -33,7 +33,7 @@ type Token struct {
 
 // convert to human readable string
 func (t Token) String() string {
-	return fmt.Sprintf(`Token{Type:"%v" Value:"%v", Line:%d Col:%d}`, t.T.String(), t.V, t.Line, t.Column)
+	return fmt.Sprintf(`Token{Type:"%v" Value:"%v", Line:%d Col:%d Q:%s}`, t.T.String(), t.V, t.Line, t.Column, t.Quote)
 }
 
 /*

--- a/lex/token.go
+++ b/lex/token.go
@@ -33,7 +33,8 @@ type Token struct {
 
 // convert to human readable string
 func (t Token) String() string {
-	return fmt.Sprintf(`Token{Type:"%v" Value:"%v", Line:%d Col:%d Q:%s}`, t.T.String(), t.V, t.Line, t.Column, t.Quote)
+	return fmt.Sprintf(`Token{ %s Type:"%v" Line:%d Col:%d Q:%s}`,
+		t.V, t.T.String(), t.Line, t.Column, string(t.Quote))
 }
 
 /*

--- a/plan/plan_proto_test.go
+++ b/plan/plan_proto_test.go
@@ -28,7 +28,7 @@ var sqlStatements = []string{
 }
 
 var sqlStatementsx = []string{
-	"SELECT name, order_id FROM orders ORDER BY name ASC;",
+	`SELECT name FROM orders WHERE name = "bob";`,
 }
 
 func init() {

--- a/rel/parse_sql.go
+++ b/rel/parse_sql.go
@@ -1555,6 +1555,7 @@ func convertIdentityToValue(n expr.Node) {
 		switch rhn := nt.Args[1].(type) {
 		case *expr.IdentityNode:
 			rh2 := expr.NewStringNode(rhn.Text)
+			rh2.Quote = rhn.Quote
 			nt.Args[1] = rh2
 		}
 	}

--- a/rel/sql.go
+++ b/rel/sql.go
@@ -864,6 +864,13 @@ func (m *SqlSelect) ToPbStatement() *SqlStatementPb {
 func (m *SqlSelect) ToPB() *SqlSelectPb {
 	return m.ToPbStatement().Select
 }
+func (m *SqlSelect) Copy() *SqlSelect {
+	pb := m.ToPB()
+	selCopy := SqlSelectFromPb(pb)
+	return selCopy
+}
+
+// SqlSelectToPb Given a select statement lets convert it into a PB statement
 func SqlSelectToPb(m *SqlSelect) *SqlSelectPb {
 	return sqlSelectToPbDepth(m, 0)
 }
@@ -1010,6 +1017,8 @@ func (m *SqlSelect) Equal(ss SqlStatement) bool {
 	}
 	return true
 }
+
+// SqlSelectFromPb take a protobuf select struct and conver to SqlSelect
 func SqlSelectFromPb(pb *SqlSelectPb) *SqlSelect {
 	ss := SqlSelect{
 		Db:        pb.GetDb(),

--- a/rel/sql.go
+++ b/rel/sql.go
@@ -1100,14 +1100,14 @@ func (m *SqlSelect) writeBuf(depth int, buf *bytes.Buffer) {
 		buf.WriteString(" WHERE ")
 		m.Where.writeBuf(buf)
 	}
-	if m.GroupBy != nil {
+	if len(m.GroupBy) > 0 {
 		buf.WriteString(" GROUP BY ")
 		m.GroupBy.writeBuf(buf)
 	}
 	if m.Having != nil {
 		buf.WriteString(fmt.Sprintf(" HAVING %s", m.Having.String()))
 	}
-	if m.OrderBy != nil {
+	if len(m.OrderBy) > 0 {
 		buf.WriteString(fmt.Sprintf(" ORDER BY %s", m.OrderBy.String()))
 	}
 	if m.Limit > 0 {

--- a/rel/sql_proto_test.go
+++ b/rel/sql_proto_test.go
@@ -10,6 +10,7 @@ import (
 
 var pbTests = []string{
 	"SELECT hash(a) AS id, `z` FROM nothing;",
+	`SELECT name FROM orders WHERE name = "bob";`,
 }
 
 func TestPb(t *testing.T) {

--- a/updateglock.sh
+++ b/updateglock.sh
@@ -13,12 +13,14 @@ cd $GOPATH/src/github.com/golang/protobuf && git checkout master && git pull
 cd $GOPATH/src/github.com/google/btree && git checkout master && git pull
 cd $GOPATH/src/github.com/hashicorp/go-immutable-radix && git checkout master && git pull
 cd $GOPATH/src/github.com/hashicorp/go-memdb && git checkout master && git pull
+cd $GOPATH/src/github.com/hashicorp/golang-lru && git checkout master && git pull
 cd $GOPATH/src/github.com/jmoiron/sqlx && git checkout master && git pull
 cd $GOPATH/src/github.com/kr/pretty && git checkout master && git pull
 cd $GOPATH/src/github.com/kr/pty && git checkout master && git pull
 cd $GOPATH/src/github.com/kr/text && git checkout master && git pull
 cd $GOPATH/src/github.com/leekchan/timeutil && git checkout master && git pull
 cd $GOPATH/src/github.com/lytics/confl && git checkout master && git pull
+cd $GOPATH/src/github.com/lytics/datemath && git checkout master && git pull
 cd $GOPATH/src/github.com/mb0/glob && git checkout master && git pull
 cd $GOPATH/src/github.com/pborman/uuid && git checkout master && git pull
 cd $GOPATH/src/github.com/rcrowley/go-metrics && git checkout master && git pull

--- a/value/value.go
+++ b/value/value.go
@@ -139,6 +139,30 @@ func (m ValueType) String() string {
 	}
 }
 
+func (m ValueType) IsMap() bool {
+	switch m {
+	case MapValueType, MapIntType, MapStringType, MapNumberType, MapTimeType, MapBoolType:
+		return true
+	}
+	return false
+}
+
+func (m ValueType) IsSlice() bool {
+	switch m {
+	case ByteSliceType, StringsType, SliceValueType:
+		return true
+	}
+	return false
+}
+
+func (m ValueType) IsNumeric() bool {
+	switch m {
+	case NumberType, IntType:
+		return true
+	}
+	return false
+}
+
 type emptyStruct struct{}
 
 type (


### PR DESCRIPTION
* new `StringNode` changes that supports single-quote marks as well as double
* bug in to-from protobufs for equality operator/token serialization
* helpers for `IsSlice(), IsMap(), IsNumeric()` on value's
* new sql select re-writer, to find all raw fields (inside functions, group-bys) and rewrite as just a raw-source for sources that don't support projections, etc.  Used when we poly-fill.
