### PR TITLE
qlcsv: Example fails due to stdin being consumed twice

### DIFF
--- a/examples/qlcsv/main.go
+++ b/examples/qlcsv/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"database/sql"
 	"flag"
 	"fmt"
 	"net/mail"
-	"os"
 	"strings"
 
 	// Side-Effect Import the qlbridge sql driver
@@ -48,18 +48,12 @@ func main() {
 	// Add a custom function to the VM to make available to SQL language
 	expr.FuncAdd("email_is_valid", EmailIsValid)
 
-	// Our file source of csv's is stdin
-	stdIn, err := os.Open("/dev/stdin")
-	if err != nil {
-		u.Errorf("could not open stdin? %v", err)
-		return
-	}
-
 	// We are registering the "csv" datasource, to show that
 	// the backend/sources can be easily created/added.  This csv
 	// reader is an example datasource that is very, very simple.
 	exit := make(chan bool)
-	src, _ := datasource.NewCsvSource("stdin", 0, stdIn, exit)
+	var dummyCsv = []byte("##")
+	src, _ := datasource.NewCsvSource("stdin", 0, bytes.NewReader(dummyCsv), exit)
 	datasource.Register("csv", src)
 
 	db, err := sql.Open("qlbridge", "csv:///dev/stdin")


### PR DESCRIPTION
The example previously failed with:
```
$ ./qlcsv -sql '
     select
         user_id, email
     FROM stdin' < users.csv
2016/10/16 17:52:09.476160 schema.go:471: could not find table "tables"
2016/10/16 17:52:09.476644 csv.go:60: Error opening bufio.peek for csv
reader EOF
2016/10/16 17:52:09.476673 planner_select.go:180: no conn? EOF
2016/10/16 17:52:09.476695 planner_select.go:40: no source? EOF
2016/10/16 17:52:09.476709 sqldriver.go:246: return error? EOF
```

The NewCsvSource call passed in stdin which was consumed, and then the
CSV source's Open was called to open /dev/stdin, but since it had
already been consumed, it caused an EOF.

After this fix, the command works as expected:
```
$ ./qlcsv -sql '
    select
        user_id, email
    FROM stdin' < users.csv
2016/10/16 17:59:18.257826 schema.go:471: could not find table "tables"


Scanning through CSV: (user_id,email)

9Ip1aKbeZe2njCDM, aaron@email.com
hT2impsOPUREcVPc, bob@gmail.com
hT2impsabc345c, not_an_email
```