### PR TITLE
plan: Add columns in projection for binary nodes

### DIFF
--- a/plan/projection.go
+++ b/plan/projection.go
@@ -206,7 +206,7 @@ func projectionForSourcePlan(plan *Source) error {
 					} else {
 						plan.Proj.AddColumnShort(col.As, value.NumberType)
 					}
-				case *expr.FuncNode:
+				case *expr.FuncNode, *expr.BinaryNode:
 					// Probably not string?
 					plan.Proj.AddColumnShort(col.As, value.StringType)
 				default:


### PR DESCRIPTION
Currently, a binary node (such as "item_count * 2") causes qlcsv to
panic:
```
$ ./qlcsv -sql '
    select
        user_id, email, not(deleted), item_count * 2
    FROM stdin WHERE not(deleted)' < users.csv
2016/10/16 18:16:10.684035 schema.go:471: could not find table "tables"
2016/10/16 18:16:10.684439 projection.go:213: schema col not found:  SourceField="item_count"   vals=&rel.Column{sourceQuoteByte:0x0, asQuoteByte:0x0, originalAs:"", left:"", right:"", isLiteral:false, ParentIndex:0, Index:3, SourceIndex:0, SourceField:"item_count", SourceOriginal:"item_count", As:"item_count", Comment:"", Order:"", Star:false, Agg:false, Expr:(*expr.BinaryNode)(0xc420014b90), Guard:expr.Node(nil)}

Scanning through CSV: (user_id,email,not_deleted,item_count)

2016/10/16 18:16:10.684934 context.go:80: context recover: runtime error: index out of range
```

The binary node does not add any column currently. Treat it the same as a function node
for now and use string. This allows the query to succeed:
```
$ ./qlcsv -sql '
    select
        user_id, email, not(deleted), item_count * 2
    FROM stdin WHERE not(deleted)' < users.csv
2016/10/16 18:15:45.864366 schema.go:471: could not find table "tables"

Scanning through CSV: (user_id,email,not_deleted,item_count)

9Ip1aKbeZe2njCDM, aaron@email.com, true, 164
hT2impsabc345c, not_an_email, true, 24
```