### PR TITLE
Make binarynode not negateable, less agressive rewrite

### DIFF
--- a/expr/node.go
+++ b/expr/node.go
@@ -50,7 +50,7 @@ var (
 	_ DialectWriter = (*defaultDialect)(nil)
 
 	// Ensure some of our nodes implement Interfaces
-	_ NegateableNode = (*BinaryNode)(nil)
+	//_ NegateableNode = (*BinaryNode)(nil)
 	_ NegateableNode = (*BooleanNode)(nil)
 	_ NegateableNode = (*TriNode)(nil)
 	_ NegateableNode = (*IncludeNode)(nil)
@@ -105,12 +105,11 @@ type (
 		// negation into here
 		Negated() bool
 		// Reverse Negation if Possible:  for instance:
-		//   NOT (a != b)    =>  a == b
-		//   NOT (a > b)     =>  a <= b
+		//   "A" NOT IN ("a","b")    =>  "A" IN ("a","b")
 		ReverseNegation() bool
 		StringNegate() string
 		WriteNegate(w DialectWriter)
-		// Negateable nodes may be collapsed logically
+		// Negateable nodes may be collapsed logically into new nodes
 		Node() Node
 	}
 
@@ -1162,50 +1161,10 @@ func NewBinaryNode(operator lex.Token, lhArg, rhArg Node) *BinaryNode {
 	return &BinaryNode{Args: []Node{lhArg, rhArg}, Operator: operator}
 }
 
-func (m *BinaryNode) ReverseNegation() bool {
-	switch m.Operator.T {
-	case lex.TokenEqualEqual:
-		m.Operator.T = lex.TokenNE
-		m.Operator.V = m.Operator.T.String()
-	case lex.TokenNE:
-		m.Operator.T = lex.TokenEqualEqual
-		m.Operator.V = m.Operator.T.String()
-	case lex.TokenLT:
-		m.Operator.T = lex.TokenGE
-		m.Operator.V = m.Operator.T.String()
-	case lex.TokenLE:
-		m.Operator.T = lex.TokenGT
-		m.Operator.V = m.Operator.T.String()
-	case lex.TokenGT:
-		m.Operator.T = lex.TokenLE
-		m.Operator.V = m.Operator.T.String()
-	case lex.TokenGE:
-		m.Operator.T = lex.TokenLT
-		m.Operator.V = m.Operator.T.String()
-	default:
-		//u.Warnf("What, what is this?   %s", m)
-		m.negated = !m.negated
-		return true
-	}
-	return true
-}
 func (m *BinaryNode) String() string {
 	w := NewDefaultWriter()
 	m.WriteDialect(w)
 	return w.String()
-}
-func (m *BinaryNode) StringNegate() string {
-	w := NewDefaultWriter()
-	m.WriteNegate(w)
-	return w.String()
-}
-func (m *BinaryNode) WriteNegate(w DialectWriter) {
-	switch m.Operator.T {
-	case lex.TokenIN, lex.TokenIntersects, lex.TokenLike, lex.TokenContains:
-		m.writeToString(w, "NOT ")
-	default:
-		m.writeToString(w, "")
-	}
 }
 func (m *BinaryNode) WriteDialect(w DialectWriter) {
 	if m.negated {
@@ -1248,8 +1207,61 @@ func (m *BinaryNode) writeToString(w DialectWriter, negate string) {
 		io.WriteString(w, ")")
 	}
 }
-func (m *BinaryNode) Node() Node    { return m }
+
+/*
+Negation
+I wanted to do negation on Binaries, but ended up not doing for now
+
+ie, rewrite   NOT (X == "y")   =>  X != "y"
+
+The general problem we ran into is that we lose some fidelity in collapsing
+AST that is necessary for other evaluation run-times.
+
+logically `NOT (X > y)` is NOT THE SAME AS  `(X <= y)   due to lack of existince of X
+
+func (m *BinaryNode) ReverseNegation() bool {
+	switch m.Operator.T {
+	case lex.TokenEqualEqual:
+		m.Operator.T = lex.TokenNE
+		m.Operator.V = m.Operator.T.String()
+	case lex.TokenNE:
+		m.Operator.T = lex.TokenEqualEqual
+		m.Operator.V = m.Operator.T.String()
+	case lex.TokenLT:
+		m.Operator.T = lex.TokenGE
+		m.Operator.V = m.Operator.T.String()
+	case lex.TokenLE:
+		m.Operator.T = lex.TokenGT
+		m.Operator.V = m.Operator.T.String()
+	case lex.TokenGT:
+		m.Operator.T = lex.TokenLE
+		m.Operator.V = m.Operator.T.String()
+	case lex.TokenGE:
+		m.Operator.T = lex.TokenLT
+		m.Operator.V = m.Operator.T.String()
+	default:
+		//u.Warnf("What, what is this?   %s", m)
+		m.negated = !m.negated
+		return true
+	}
+	return true
+}
+func (m *BinaryNode) Node() Node { return m }
 func (m *BinaryNode) Negated() bool { return m.negated }
+func (m *BinaryNode) StringNegate() string {
+	w := NewDefaultWriter()
+	m.WriteNegate(w)
+	return w.String()
+}
+func (m *BinaryNode) WriteNegate(w DialectWriter) {
+	switch m.Operator.T {
+	case lex.TokenIN, lex.TokenIntersects, lex.TokenLike, lex.TokenContains:
+		m.writeToString(w, "NOT ")
+	default:
+		m.writeToString(w, "")
+	}
+}
+*/
 func (m *BinaryNode) Validate() error {
 	for _, n := range m.Args {
 		if err := n.Validate(); err != nil {
@@ -1385,6 +1397,7 @@ func (m *BooleanNode) Node() Node {
 					return nn
 				}
 			}
+			return NewUnary(m.Operator, m.Args[0])
 		}
 		return m.Args[0]
 	}
@@ -1603,6 +1616,13 @@ func NewUnary(operator lex.Token, arg Node) Node {
 			nn.ReverseNegation()
 			return nn.Node()
 		}
+	}
+
+	// In the event we are adding a binary here, we might have
+	// rewritten a little so lets make sure its interpreted/nested coorectly
+	bn, isBinary := arg.(*BinaryNode)
+	if isBinary {
+		bn.Paren = true
 	}
 
 	return &UnaryNode{Arg: arg, Operator: operator}

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -518,6 +518,7 @@ func (t *tree) F(depth int) Node {
 		return t.v(depth)
 	case lex.TokenNegate, lex.TokenMinus, lex.TokenExists:
 		t.Next()
+		debugf(depth, "cur: %v   next:%v", cur, t.Cur())
 		n := NewUnary(cur, t.F(depth+1))
 		debugf(depth, "f urnary: %s", n)
 		return n

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -192,12 +192,12 @@ var exprTests = []exprTest{
 	},
 	{
 		`NOT OR (x == "y")`,
-		`x != "y"`,
+		`NOT (x == "y")`,
 		true,
 	},
 	{
 		`NOT AND (x == "y")`,
-		`x != "y"`,
+		`NOT (x == "y")`,
 		true,
 	},
 	{

--- a/rel/filter_test.go
+++ b/rel/filter_test.go
@@ -17,14 +17,14 @@ func filterEqual(t *testing.T, ql1, ql2 string) {
 	assert.Equal(t, nil, err)
 	f2, err := ParseFilterQL(ql2)
 	assert.Equal(t, nil, err)
-	assert.Tf(t, f1.Equal(f2), "f1 should equal f2:  %s", ql1)
+	assert.Tf(t, f1.Equal(f2), "Should Equal: \nf1:%s   %s \nf2:%s  %s", ql1, f1, ql2, f2.String())
 }
 
 func TestFilterEquality(t *testing.T) {
 	t.Parallel()
 
 	filterEqual(t, `FILTER OR (x == "y")`, `FILTER x == "y"`)
-	filterEqual(t, `FILTER NOT OR (x == "y")`, `FILTER x != "y"`)
-	filterEqual(t, `FILTER NOT AND (x == "y")`, `FILTER x != "y"`)
+	filterEqual(t, `FILTER NOT OR (x == "y")`, `FILTER NOT (x == "y")`)
+	filterEqual(t, `FILTER NOT AND (x == "y")`, `FILTER NOT (x == "y")`)
 	filterEqual(t, `FILTER AND (x == "y" , AND ( stuff == x ))`, `FILTER AND (x == "y" , stuff == x )`)
 }

--- a/rel/parse_filterql_test.go
+++ b/rel/parse_filterql_test.go
@@ -267,11 +267,12 @@ func TestFilterQLAstCheck(t *testing.T) {
 	req, err = ParseFilterQL(ql)
 	assert.Equal(t, err, nil)
 	assert.NotEqual(t, req, nil, ql, err)
-	bn := req.Filter.(*expr.BinaryNode)
+	un := req.Filter.(*expr.UnaryNode)
+	bn := un.Arg.(*expr.BinaryNode)
 	u.Warnf("t %T", req.Filter)
 	assert.Equalf(t, len(bn.Args), 2, "has binary expression: %#v", f)
-	assert.Equalf(t, bn.String(), `name != "bob"`, "Should have expr %v", bn)
-	assert.Equalf(t, req.String(), `FILTER name != "bob" ALIAS root`, "roundtrip? %v", req.String())
+	assert.Equalf(t, bn.String(), `(name == "bob")`, "Should have expr %v", bn)
+	assert.Equalf(t, req.String(), `FILTER NOT (name == "bob") ALIAS root`, "roundtrip? %v", req.String())
 
 	ql = `FILTER OR ( INCLUDE child_1, INCLUDE child_2 ) ALIAS root`
 	req, err = ParseFilterQL(ql)
@@ -414,7 +415,7 @@ func TestFilterQLAstCheck(t *testing.T) {
 	assert.NotEqual(t, req, nil, ql, err)
 	assert.Equalf(t, req.Alias, "my_filter_name", "has alias: %q", req.Alias)
 	assert.Tf(t, req.From == "user", "has FROM: %q", req.From)
-	un := req.Filter.(*expr.UnaryNode)
+	un = req.Filter.(*expr.UnaryNode)
 	assert.Equalf(t, un.String(), "EXISTS datefield", "%#v", un)
 
 	// Make sure we have a HasDateMath flag

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -74,6 +74,9 @@ func TestFilterQlVm(t *testing.T) {
 	nc := datasource.NewNestedContextReader(readers, time.Now())
 	incctx := expr.NewIncludeContext(nc)
 
+	// hits := []string{
+	// 	`FILTER NOT ( FakeDate > "now-1d") `, // Date Math (negated, missing field)
+	// }
 	hits := []string{
 		`FILTER name == "Yoda"`,                                // upper case sensitive name
 		`FILTER name != "yoda"`,                                // we should be case-sensitive by default
@@ -92,6 +95,8 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER roles NOT INTERSECTS ("user", "guest")`,        // Intersects
 		`FILTER Created BETWEEN "12/01/2015" AND "01/01/2016"`, // Between Operator
 		`FILTER Created < "now-1d"`,                            // Date Math
+		`FILTER NOT ( Created > "now-1d") `,                    // Date Math (negated)
+		`FILTER NOT ( FakeDate > "now-1d") `,                   // Date Math (negated, missing field)
 		`FILTER Updated > "now-2h"`,                            // Date Math
 		`FILTER FirstEvent.signedup < "now-2h"`,                // Date Math on map[string]time
 		`FILTER FirstEvent.signedup == "12/18/2015"`,           // Date equality on map[string]time
@@ -131,6 +136,8 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER hits.foo > "1.5"`,
 		`FILTER NOT ( hits.foo > 5.5 )`,
 	}
+	//u.Debugf("len hits: %v", len(hitsx))
+	//expr.Trace = true
 
 	for _, q := range hits {
 		fs, err := rel.ParseFilterQL(q)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -313,14 +313,14 @@ func walkBinary(ctx expr.EvalContext, node *expr.BinaryNode, depth int) (value.V
 	if !ok {
 		return nil, ok
 	}
-	if node.Negated() {
-		bv, isBool := val.(value.BoolValue)
-		if isBool {
-			return value.NewBoolValue(!bv.Val()), true
-		}
-		// This should not be possible
-		u.Warnf("Negated binary but non bool response? %T expr:%s", val, node)
-	}
+	// if node.Negated() {
+	// 	bv, isBool := val.(value.BoolValue)
+	// 	if isBool {
+	// 		return value.NewBoolValue(!bv.Val()), true
+	// 	}
+	// 	// This should not be possible
+	// 	u.Warnf("Negated binary but non bool response? %T expr:%s", val, node)
+	// }
 	return val, ok
 }
 func evalBinary(ctx expr.EvalContext, node *expr.BinaryNode, depth int) (value.Value, bool) {


### PR DESCRIPTION
Binary Nodes can't be re-written without losing fidelity on original statement necessary for other runtimes (elasticsearch)


ie:

```
NOT (x > y)    
# DOES NOT EQUAL
x <= y
```

Because missing field on left hand side