### PR TITLE
FilterQL vm needs to support nested INCLUDE *

### DIFF
--- a/rel/parse_filterql.go
+++ b/rel/parse_filterql.go
@@ -102,6 +102,13 @@ func (f *FilterQLParser) ParseFilterSelects() (stmts []*FilterSelect, err error)
 func ParseFilters(statement string) (stmts []*FilterStatement, err error) {
 	return NewFilterParser(statement).ParseFilters()
 }
+func MustParseFilters(statement string) []*FilterStatement {
+	stmts, err := ParseFilters(statement)
+	if err != nil {
+		panic(err.Error())
+	}
+	return stmts
+}
 
 // ParseFilterQL Parses a FilterQL statement
 func ParseFilterQL(filter string) (*FilterStatement, error) {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -238,6 +238,13 @@ func walkInclude(ctx expr.EvalContext, inc *expr.IncludeNode, depth int) (value.
 		}
 	}
 
+	switch exp := inc.ExprNode.(type) {
+	case *expr.IdentityNode:
+		if exp.Text == "*" || exp.Text == "match_all" {
+			return value.NewBoolValue(true), true
+		}
+	}
+
 	matches, ok := evalBool(ctx, inc.ExprNode, depth+1)
 	//u.Debugf("matches filter?%v ok=%v  f=%q", matches, ok, bn)
 	if !ok {


### PR DESCRIPTION
Need to support included match all

```
# given include:
FILTER * ALIAS  match_all_include;




# these statements will not pass, were broken before
`FILTER OR (
	name == "Rey"     -- false 
	INCLUDE match_all_include
)`,
`FILTER OR (
	name == "Rey"     -- false 
	INCLUDE is_yoda_true
)`,



```