### PR TITLE
adding missing interface back in

### DIFF
--- a/schema/datasource.go
+++ b/schema/datasource.go
@@ -52,6 +52,10 @@ type (
 		Table(table string) (*Table, error)
 		// Create/Alter TODO
 	}
+	// SourceTableSchema Partial interface for just Table()
+	SourceTableSchema interface {
+		Table(table string) (*Table, error)
+	}
 	// SourcePartitionable DataSource that is partitionable into ranges for splitting
 	//  reads, writes onto different nodes.
 	SourcePartitionable interface {


### PR DESCRIPTION
Add the SourceTableSchema interface back in.  It turns out we still needed it. 