### PR TITLE
Add Expression Inliner for includes

### DIFF
--- a/expr/include.go
+++ b/expr/include.go
@@ -27,7 +27,7 @@ func inlineIncludesDepth(ctx Includer, arg Node, depth int) (Node, error) {
 	if depth > maxIncludeDepth {
 		return nil, ErrMaxDepth
 	}
-	// can we switch to arg.Type()
+
 	switch n := arg.(type) {
 	case NodeArgs:
 		args := n.ChildrenArgs()

--- a/expr/include.go
+++ b/expr/include.go
@@ -1,0 +1,82 @@
+package expr
+
+import (
+	"fmt"
+
+	u "github.com/araddon/gou"
+
+	"github.com/araddon/qlbridge/lex"
+)
+
+const (
+	maxIncludeDepth = 100
+)
+
+var (
+
+	// If we hit max depth
+	ErrMaxDepth = fmt.Errorf("Recursive Evaluation Error")
+)
+
+// InlineIncludes take an expression and resolve any includes so that
+// the included expression is "Inline"
+func InlineIncludes(ctx Includer, n Node) (Node, error) {
+	return inlineIncludesDepth(ctx, n, 0)
+}
+func inlineIncludesDepth(ctx Includer, arg Node, depth int) (Node, error) {
+	if depth > maxIncludeDepth {
+		return nil, ErrMaxDepth
+	}
+	// can we switch to arg.Type()
+	switch n := arg.(type) {
+	case NodeArgs:
+		args := n.ChildrenArgs()
+		for i, narg := range args {
+			newNode, err := inlineIncludesDepth(ctx, narg, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			if newNode != nil {
+				args[i] = newNode
+			}
+		}
+		return arg, nil
+	case *NumberNode, *IdentityNode, *StringNode, nil,
+		*ValueNode, *NullNode:
+		return nil, nil
+	case *IncludeNode:
+		return resolveInclude(ctx, n, depth+1)
+	}
+	return nil, fmt.Errorf("unrecognized node type %T", arg)
+}
+
+func resolveInclude(ctx Includer, inc *IncludeNode, depth int) (Node, error) {
+
+	if inc.inlineExpr == nil {
+		n, err := ctx.Include(inc.Identity.Text)
+		if err != nil {
+			// ErrNoIncluder is pretty common so don't log it
+			if err == ErrNoIncluder {
+				return nil, err
+			}
+			u.Debugf("Could not find include for filter:%s err=%v", inc.String(), err)
+			return nil, err
+		}
+		if n == nil {
+			u.Debugf("Includer %T returned a nil filter statement!", inc)
+			return nil, ErrIncludeNotFound
+		}
+		// Now inline, the inlines
+		n, err = InlineIncludes(ctx, n)
+		if err != nil {
+			return nil, err
+		}
+		if inc.Negated() {
+			inc.inlineExpr = NewUnary(lex.Token{T: lex.TokenNegate, V: "NOT"}, n)
+		} else {
+			inc.inlineExpr = n
+		}
+
+	}
+	return inc.inlineExpr, nil
+}

--- a/expr/include_test.go
+++ b/expr/include_test.go
@@ -56,6 +56,10 @@ func TestInlineIncludes(t *testing.T) {
 	nc := datasource.NewNestedContextReader(readers, time.Now())
 	includerCtx := newIncluderCtx(nc, `
 		FILTER name == "Yoda" ALIAS is_yoda_true;
+		FILTER AND (
+			planet == "Dagobah"
+			INCLUDE is_yoda_true
+		) ALIAS nested_includes_yoda;
 	`)
 
 	tests := []incTest{
@@ -70,6 +74,10 @@ func TestInlineIncludes(t *testing.T) {
 		{
 			in:  `AND ( lastvisit_ts < "now-1d", NOT INCLUDE is_yoda_true )`,
 			out: `AND ( lastvisit_ts < "now-1d", NOT (name == "Yoda") )`,
+		},
+		{
+			in:  `AND ( lastvisit_ts < "now-1d", NOT INCLUDE nested_includes_yoda )`,
+			out: `AND ( lastvisit_ts < "now-1d", NOT AND ( planet == "Dagobah", (name == "Yoda") ) )`,
 		},
 	}
 	for _, tc := range tests {

--- a/expr/include_test.go
+++ b/expr/include_test.go
@@ -1,0 +1,96 @@
+package expr_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/araddon/qlbridge/datasource"
+	"github.com/araddon/qlbridge/expr"
+	"github.com/araddon/qlbridge/rel"
+	//"github.com/araddon/qlbridge/vm"
+)
+
+type includectx struct {
+	expr.ContextReader
+	segs map[string]*rel.FilterStatement
+}
+
+func newIncluderCtx(cr expr.ContextReader, statements string) *includectx {
+	stmts := rel.MustParseFilters(statements)
+	segs := make(map[string]*rel.FilterStatement, len(stmts))
+	for _, stmt := range stmts {
+		segs[strings.ToLower(stmt.Alias)] = stmt
+	}
+	return &includectx{ContextReader: cr, segs: segs}
+}
+func (m *includectx) Include(name string) (expr.Node, error) {
+	if seg, ok := m.segs[strings.ToLower(name)]; ok {
+		return seg.Filter, nil
+	}
+	return nil, expr.ErrNoIncluder
+}
+
+type incTest struct {
+	in  string
+	out string
+}
+
+func TestInlineIncludes(t *testing.T) {
+
+	t1 := time.Now()
+
+	readers := []expr.ContextReader{
+		datasource.NewContextMap(map[string]interface{}{
+			"name":       "bob",
+			"city":       "Peoria, IL",
+			"zip":        5,
+			"signedup":   t1,
+			"lastevent":  map[string]time.Time{"signedup": t1},
+			"last.event": map[string]time.Time{"has.period": t1},
+		}, true),
+	}
+
+	nc := datasource.NewNestedContextReader(readers, time.Now())
+	includerCtx := newIncluderCtx(nc, `
+		FILTER name == "Yoda" ALIAS is_yoda_true;
+	`)
+
+	tests := []incTest{
+		{
+			in:  `lastvisit_ts < "now-1d"`,
+			out: `lastvisit_ts < "now-1d"`,
+		},
+		{
+			in:  `AND ( lastvisit_ts < "now-1d", INCLUDE is_yoda_true )`,
+			out: `AND ( lastvisit_ts < "now-1d", name == "Yoda" )`,
+		},
+		{
+			in:  `AND ( lastvisit_ts < "now-1d", NOT INCLUDE is_yoda_true )`,
+			out: `AND ( lastvisit_ts < "now-1d", NOT (name == "Yoda") )`,
+		},
+	}
+	for _, tc := range tests {
+		n := expr.MustParse(tc.in)
+		out, err := expr.InlineIncludes(includerCtx, n)
+		assert.Equal(t, nil, err)
+		assert.NotEqual(t, nil, out)
+		if out != nil {
+			assert.Equal(t, tc.out, out.String())
+		}
+	}
+
+	testsErr := []incTest{
+		{
+			in:  `AND ( lastvisit_ts < "now-1d", INCLUDE not_gonna_be_found )`,
+			out: `AND ( lastvisit_ts < "now-1d", name == "Yoda" )`,
+		},
+	}
+	for _, tc := range testsErr {
+		n := expr.MustParse(tc.in)
+		_, err := expr.InlineIncludes(includerCtx, n)
+		assert.NotEqual(t, nil, err)
+	}
+}

--- a/rel/parse_filterql.go
+++ b/rel/parse_filterql.go
@@ -13,7 +13,9 @@ import (
 
 // FilterQLParser
 type FilterQLParser struct {
-	statement string //can be a FilterStatement, FilterStatements, filterSelect, filterSelects, etc.  Which one is determined by which Parser func you call.
+	// can be a FilterStatement, FilterStatements, filterSelect, filterSelects, etc.
+	// Which one is determined by which Parser func you call.
+	statement string
 	fs        *FilterStatement
 	l         *lex.Lexer
 	comment   string


### PR DESCRIPTION
closes #181 allow nested expressions that are referenced by the `INCLUDE` statement to be inlined for easier reading.