### PR TITLE
Make inline includes non-muteable

### DIFF
--- a/expr/include.go
+++ b/expr/include.go
@@ -21,7 +21,13 @@ var (
 // InlineIncludes take an expression and resolve any includes so that
 // the included expression is "Inline"
 func InlineIncludes(ctx Includer, n Node) (Node, error) {
-	return inlineIncludesDepth(ctx, n, 0)
+	// We need to make a copy, so we lazily use the To/From pb
+	// We need the copy because we are going to mutate this node
+	// but AST is assumed to be immuteable, and shared, since we are breaking
+	// this contract we copy
+	npb := n.NodePb()
+	newNode := NodeFromNodePb(npb)
+	return inlineIncludesDepth(ctx, newNode, 0)
 }
 func inlineIncludesDepth(ctx Includer, arg Node, depth int) (Node, error) {
 	if depth > maxIncludeDepth {
@@ -76,7 +82,6 @@ func resolveInclude(ctx Includer, inc *IncludeNode, depth int) (Node, error) {
 		} else {
 			inc.inlineExpr = n
 		}
-
 	}
 	return inc.inlineExpr, nil
 }

--- a/expr/include_test.go
+++ b/expr/include_test.go
@@ -71,12 +71,18 @@ func TestInlineIncludes(t *testing.T) {
 			out: `AND ( lastvisit_ts < "now-1d", name == "Yoda" )`,
 		},
 		{
-			in:  `AND ( lastvisit_ts < "now-1d", NOT INCLUDE is_yoda_true )`,
-			out: `AND ( lastvisit_ts < "now-1d", NOT (name == "Yoda") )`,
+			in:  `AND ( lastvisit_ts < "now-2d", NOT INCLUDE is_yoda_true )`,
+			out: `AND ( lastvisit_ts < "now-2d", NOT (name == "Yoda") )`,
 		},
 		{
-			in:  `AND ( lastvisit_ts < "now-1d", NOT INCLUDE nested_includes_yoda )`,
-			out: `AND ( lastvisit_ts < "now-1d", NOT AND ( planet == "Dagobah", (name == "Yoda") ) )`,
+			in:  `AND ( lastvisit_ts < "now-3d", NOT INCLUDE nested_includes_yoda )`,
+			out: `AND ( lastvisit_ts < "now-3d", NOT AND ( planet == "Dagobah", (name == "Yoda") ) )`,
+		},
+	}
+	tests = []incTest{
+		{
+			in:  `AND ( lastvisit_ts < "now-3d", NOT INCLUDE nested_includes_yoda )`,
+			out: `AND ( lastvisit_ts < "now-3d", NOT AND ( planet == "Dagobah", name == "Yoda" ) )`,
 		},
 	}
 	for _, tc := range tests {

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -563,8 +563,8 @@ func (t *tree) F(depth int) Node {
 			t.expect(lex.TokenRightParenthesis, "input")
 			t.boolean = false
 			t.Next()
-			debugf(depth, "found boolean expression %v", n.Node())
-			return n.Node()
+			//debugf(depth, "found boolean expression %v", n.Collapse())
+			return n.Collapse()
 		}
 		t.unexpected(t.Cur(), "Expected Left Paren after AND/OR ()")
 	default:


### PR DESCRIPTION
the `InlineIncludes` was breaking an assumption that AST is immuteable, so we were mutating shared state.   This fixes that bad usage, and instead creates copies so we aren't mutating shared state.