### PR TITLE
#198 filterql lex bug on newlines

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -595,6 +595,7 @@ func (t *tree) v(depth int) Node {
 	case lex.TokenValue:
 		n := NewStringNodeToken(cur)
 		t.Next()
+		debugf(depth, "after value %v", t.Cur())
 		return n
 	case lex.TokenValueEscaped:
 		n := NewStringNeedsEscape(cur)

--- a/lex/dialect_filterql.go
+++ b/lex/dialect_filterql.go
@@ -71,17 +71,20 @@ func LexFilterClause(l *Lexer) StateFn {
 
 	if l.SkipWhiteSpacesNewLine() {
 		l.Emit(TokenNewLine)
+		debugf("%p LexFilterClause emit new line stack=%d", l, len(l.stack))
+		l.Push("LexFilterClause", LexFilterClause)
 		return LexFilterClause
 	}
 
 	if l.IsComment() {
 		l.Push("LexFilterClause", LexFilterClause)
+		debugf("%p LexFilterClause comment stack=%d", l, len(l.stack))
 		return LexComment
 	}
 
 	keyWord := strings.ToLower(l.PeekWord())
 
-	//u.Debugf("%p LexFilterClause  r=%-15q stack=%d", l, string(keyWord), len(l.stack))
+	debugf("%p LexFilterClause  r=%-15q stack=%d", l, string(keyWord), len(l.stack))
 
 	switch keyWord {
 	case "from", "with":

--- a/rel/parse_filterql_test.go
+++ b/rel/parse_filterql_test.go
@@ -29,6 +29,15 @@ var FilterTests = []string{
 	`FILTER COMPANY IN ("Toys R"" Us", "Toys R' Us, Inc.")`,
 	`FILTER *`,
 	`
+	FILTER AND (
+        a IN ("Analyst")
+        b IN ("C-Level Other")
+        c IN ("Management")
+    )
+    FROM x
+    ALIAS abc
+    `,
+	`
 		FILTER score > 0
 		WITH
 			name = "My Little Pony",
@@ -192,6 +201,20 @@ func TestFilterErrMsg(t *testing.T) {
 	_, err := rel.ParseFilterQL("FILTER * FROM user ALIAS ALIAS stuff")
 	assert.NotEqual(t, err, nil, "Should have errored")
 	assert.True(t, strings.Contains(err.Error(), "Line 1"), err)
+}
+
+func TestFilterNewLines(t *testing.T) {
+	t.Parallel()
+	_, err := rel.ParseFilterQL(`
+	FILTER AND (
+        a IN ("Analyst")
+        b IN ("C-Level Other")
+        c IN ("Management")
+    )
+    FROM x
+    ALIAS abc
+    `)
+	assert.Equal(t, nil, err)
 }
 
 func TestFilterQlRoundTrip(t *testing.T) {


### PR DESCRIPTION
closes #198  FilterQL statements didn't appropriately handle new-line delimiters in all circumstances.