### PR TITLE
Fix qlcsv example and update README for schema revamp

### DIFF
--- a/examples/qlcsv/main.go
+++ b/examples/qlcsv/main.go
@@ -56,7 +56,7 @@ func main() {
 	src, _ := datasource.NewCsvSource("stdin", 0, bytes.NewReader([]byte("##")), exit)
 	schema.RegisterSourceAsSchema("example_csv", src)
 
-	db, err := sql.Open("qlbridge", "example_csv:///dev/stdin")
+	db, err := sql.Open("qlbridge", "example_csv")
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
First of all thanks for this awesome package!

When I tried to run the qlcsv example I got an error message 
```
2018/03/24 17:58:53.433890 log.go:304: could not execute query: No schema was found for "example_csv:///dev/stdin"
```

I made a change to the data source name in the `sql.Open()` call, removing the `:///dev/stdin` which seemed to cause the issue. It's likely that this has been broken since Oct 22 2017 when you had the "schema revamp" commit. I'm guessing the example should work as written and the SQL driver should parse the connection string before passing it to the default registry's `Schema()` method, whereas it currently just ends up passing the entire connection string. I haven't attempted to fix this as I'm not sure whether you intend the driver or the registry to have the responsibility of parsing the connection information, and there don't seem to be any tests covering it. 

This also updates and corrects the CSV example in the README.