### PR TITLE
In unixtrunc handle negatives and decimal percision

### DIFF
--- a/datasource/csv.go
+++ b/datasource/csv.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	u "github.com/araddon/gou"
-
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/schema"
 	"github.com/araddon/qlbridge/value"
@@ -163,7 +162,7 @@ func (m *CsvDataSource) Next() schema.Message {
 			}
 			m.rowct++
 			if len(row) != len(m.headers) {
-				u.Warnf("headers/cols dont match, dropping expected:%d got:%d   vals=", len(m.headers), len(row), row)
+				u.Warnf("headers/cols dont match, dropping expected:%d got:%d vals=%v", len(m.headers), len(row), row)
 				continue
 			}
 			vals := make([]driver.Value, len(row))

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/araddon/dateparse"
 	u "github.com/araddon/gou"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/araddon/qlbridge/datasource"
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
 	"github.com/araddon/qlbridge/vm"
+	"github.com/stretchr/testify/assert"
 )
 
 var _ = u.EMPTY
@@ -98,6 +97,7 @@ var (
 		"event":        {"hello"},
 		"reg_date":     {"10/13/2014"},
 		"msdate":       {"1438445529707"},
+		"msdate2":      {"1950-05-08 19:00:00.998"},
 		"price":        {"$55"},
 		"email":        {"email@email.com"},
 		"emails":       {"email1@email.com", "email2@email.com"},
@@ -713,8 +713,10 @@ var builtinTests = []testBuiltins{
 	{`unixtrunc("1438445529", "ms")`, value.NewStringValue("1438445529000")},
 	{`unixtrunc(todate(msdate))`, value.NewStringValue("1438445529")},
 	{`unixtrunc(todate(msdate), "seconds")`, value.NewStringValue("1438445529.707")},
+	{`unixtrunc(todate(msdate2))`, value.NewStringValue("-620110800")},
+	{`unixtrunc(todate(msdate2), "seconds")`, value.NewStringValue("-620110799.002")},
 	{`unixtrunc(reg_date, "milliseconds")`, value.NewStringValue("1413158400000")},
-	{`unixtrunc(reg_date, "seconds")`, value.NewStringValue("1413158400.0")},
+	{`unixtrunc(reg_date, "seconds")`, value.NewStringValue("1413158400.000")},
 	{`unixtrunc("hello")`, value.ErrValue},
 	{`unixtrunc("hello","seconds")`, value.ErrValue},
 	{`unixtrunc(reg_date,Address)`, value.ErrValue},

--- a/expr/builtins/time.go
+++ b/expr/builtins/time.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/araddon/dateparse"
 	u "github.com/araddon/gou"
-	"github.com/leekchan/timeutil"
-	"github.com/lytics/datemath"
-
 	"github.com/araddon/qlbridge/expr"
 	"github.com/araddon/qlbridge/value"
+	"github.com/leekchan/timeutil"
+	"github.com/lytics/datemath"
 )
 
 var _ = u.EMPTY
@@ -553,7 +552,11 @@ func timeTruncEvalTwo(ctx expr.EvalContext, args []value.Value) (value.Value, bo
 	switch format {
 	case "s", "seconds":
 		// If seconds: add milliseconds after the decimal place.
-		return value.NewStringValue(fmt.Sprintf("%d.%d", valTs/1000, valTs%1000)), true
+		milli := valTs % 1000
+		if milli < 0 {
+			milli = milli * -1
+		}
+		return value.NewStringValue(fmt.Sprintf("%d.%03d", valTs/1000, milli)), true
 	case "ms", "milliseconds":
 		// Otherwise return the Unix ts w/ milliseconds.
 		return value.NewStringValue(fmt.Sprintf("%d", valTs)), true

--- a/expr/parse.go
+++ b/expr/parse.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	u "github.com/araddon/gou"
-
 	"github.com/araddon/qlbridge/lex"
 	"github.com/araddon/qlbridge/value"
 )
@@ -415,7 +414,7 @@ func (t *tree) cInner(n Node, depth int) Node {
 				t.Next()
 				val, err := ValueArray(depth, t.TokenPager)
 				if err != nil {
-					t.errorf("Could not build an array", err)
+					t.errorf("Could not build an array: %v", err)
 				}
 				return NewBinaryNode(cur, n, NewValueNode(val))
 			case lex.TokenLeftParenthesis:


### PR DESCRIPTION
Negative unix timestamps were printing like `-129343.-122`
Also, the millisecond time was printed without zero padding so `121234.001` was coming through as `12134.1`