### PR TITLE
Add new string.index() and string.substr() functions

### DIFF
--- a/expr/builtins/builtins.go
+++ b/expr/builtins/builtins.go
@@ -72,9 +72,13 @@ func LoadAllBuiltins() {
 		// String Functions
 		expr.FuncAdd("contains", &Contains{})
 		expr.FuncAdd("tolower", &LowerCase{})
+		expr.FuncAdd("string.index", &StringIndex{})
 		expr.FuncAdd("string.lowercase", &LowerCase{})
 		expr.FuncAdd("string.uppercase", &UpperCase{})
 		expr.FuncAdd("string.titlecase", &TitleCase{})
+		expr.FuncAdd("string.split", &Split{})
+		expr.FuncAdd("string.strip", &Strip{})
+		expr.FuncAdd("string.substr", &SubString{})
 		expr.FuncAdd("split", &Split{})
 		expr.FuncAdd("strip", &Strip{})
 		expr.FuncAdd("replace", &Replace{})

--- a/expr/builtins/list_map.go
+++ b/expr/builtins/list_map.go
@@ -122,7 +122,7 @@ func (m *ArraySlice) Type() value.ValueType { return value.UnknownType }
 // Validate must be at least 2 args, max of 3
 func (m *ArraySlice) Validate(n *expr.FuncNode) (expr.EvaluatorFunc, error) {
 	if len(n.Args) < 2 || len(n.Args) > 3 {
-		return nil, fmt.Errorf("Expected 2 OR 3 args for ArraySlice(array, start, [end]) but got %s", n)
+		return nil, fmt.Errorf("Expected 2 OR 3 args for array.slice(array, start, [end]) but got %s", n)
 	}
 	return arraySliceEval, nil
 }

--- a/expr/builtins/string.go
+++ b/expr/builtins/string.go
@@ -169,8 +169,8 @@ func stringIndexEval(ctx expr.EvalContext, vals []value.Value) (value.Value, boo
 
 // Strip a string, removing leading/trailing whitespace
 //
-//    strings("apples, oranges ", 0, 3) => {"app"}
-//    substr("apples ", strings)                     => "apples"
+//    string.substr("apples, oranges ", 0, 3) => "app"
+//    string.substr("apple", 3)                     => "le"
 //
 type SubString struct{}
 


### PR DESCRIPTION
Creating 2 new function for the expression vm builtin libs

* `string.index("android", "droid")`  => 2
* `string.substr("android", 2)` => "droid"  
* `string.substr("android", 0, 3)` => "and"