### PR TITLE
Redefine IN to match INTERSECTS in all cases

### DIFF
--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -118,7 +118,7 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER name CONTAINS "od"`,                            // Contains
 		`FILTER name NOT CONTAINS "kin"`,                       // Contains
 		`FILTER roles INTERSECTS ("user", "api")`,              // Intersects
-		`FILTER roles IN ("user", "api")`,  					// #14564 IN is now a synonym of INTERSECTS when used with slices
+		`FILTER roles IN ("user", "api")`,                      // #14564 IN is now a synonym of INTERSECTS when used with slices
 		`FILTER roles NOT INTERSECTS ("user", "guest")`,        // Intersects
 		`FILTER Created BETWEEN "12/01/2015" AND "01/01/2016"`, // Between Operator
 		`FILTER Created < "now-1d"`,                            // Date Math

--- a/vm/filterqlvm_test.go
+++ b/vm/filterqlvm_test.go
@@ -118,6 +118,7 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER name CONTAINS "od"`,                            // Contains
 		`FILTER name NOT CONTAINS "kin"`,                       // Contains
 		`FILTER roles INTERSECTS ("user", "api")`,              // Intersects
+		`FILTER roles IN ("user", "api")`,  					// #14564 IN is now a synonym of INTERSECTS when used with slices
 		`FILTER roles NOT INTERSECTS ("user", "guest")`,        // Intersects
 		`FILTER Created BETWEEN "12/01/2015" AND "01/01/2016"`, // Between Operator
 		`FILTER Created < "now-1d"`,                            // Date Math
@@ -131,8 +132,8 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER lastevent.signedup == "12/18/2015"`,            // Date equality on map[string]time
 		"FILTER `lastevent`.`signedup` == \"12/18/2015\"",      // escaping of field names using backticks
 		"FILTER `last.event`.`has.period` == \"12/18/2015\"",   // escaping of field names using backticks
-		// Maps when used as IN, INTERSECTS have weird inferred "keys"
-		`FILTER hits IN ("foo")`,
+		`FILTER hits INTERSECTS ("bar", "foo")`,
+		`FILTER hits IN ("bar", "foo")`, // IN means the same as INTERSECTS with respect to map keys
 		`FILTER hits NOT IN ("not-gonna-happen")`,
 		`FILTER lastevent IN ("signedup")`,
 		`FILTER lastevent NOT IN ("not-gonna-happen")`,
@@ -204,7 +205,6 @@ func TestFilterQlVm(t *testing.T) {
 		`FILTER AND (name == "Yoda", city == "xxx", zip == 5)`,
 		`FILTER lastevent.signedup > "now-2h"`,      // Date Math on map[string]time
 		`FILTER lastevent.signedup != "12/18/2015"`, // Date equality on map[string]time
-		`FILTER roles IN ("user", "api")`,           // []string IN []string  IN operator on slices is not supported
 		`FILTER transactionsnil < "now-1h"`,         // Date Compare with empty slice
 		`FILTER ["hello","apple"] < "now-1h"`,       // Date Compare with left hand strings
 		`FILTER zip * 5 * 2`,                        // invalid statement

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 var (
 	t0       = dateparse.MustParse("12/18/2015")
 	t1       = dateparse.MustParse("12/18/2039")
-	tcreated = dateparse.MustParse("12/18/2019")
+	tcreated = time.Now().AddDate(0,0,-14) // 14 days ago
 	// This is the message context which will be added to all tests below
 	//  and be available to the VM runtime for evaluation by using
 	//  key's such as "int5" or "user_id"


### PR DESCRIPTION
Changes:
- Modifies the IN operator to behave always the same as the INTERSECTS operator.  Previously `evalBinary` would always return `false` in the case of `slicefield IN ("literal")`; now it will be treated as an INTERSECTS in that case.  (Curiously, `IN` was already being treated as `INTERSECTS` for the case of map fields).

This change is requested due to inconsistencies between this VM and ES.