### PR TITLE
Add `unsign` function for converting ints to uint strings

### DIFF
--- a/expr/builtins/builtins.go
+++ b/expr/builtins/builtins.go
@@ -68,6 +68,7 @@ func LoadAllBuiltins() {
 		expr.FuncAdd("tobool", &ToBool{})
 		expr.FuncAdd("toint", &ToInt{})
 		expr.FuncAdd("tonumber", &ToNumber{})
+		expr.FuncAdd("unsign", &Unsign{})
 
 		// String Functions
 		expr.FuncAdd("contains", &Contains{})

--- a/expr/builtins/builtins_test.go
+++ b/expr/builtins/builtins_test.go
@@ -658,7 +658,17 @@ var builtinTests = []testBuiltins{
 	{`tostring(true)`, value.NewStringValue("true")},
 	{`tostring(1)`, value.NewStringValue("1")},
 	{`tostring("")`, value.NewStringValue("")},
-	// {`tostring(not_a_field)`, value.ErrValue},
+
+	{`unsign(false)`, value.ErrValue},
+	{`unsign("howdy")`, value.ErrValue},
+	{`unsign(0)`, value.NewStringValue("0")},
+	{`unsign(-794)`, value.NewStringValue("18446744073709550822")},
+	{`unsign(794)`, value.NewStringValue("794")},
+	{`unsign("-7941778727260920248")`, value.NewStringValue("10504965346448631368")},
+	{`unsign("7941778727260920248")`, value.NewStringValue("7941778727260920248")},
+	{`unsign(7941778727260920248)`, value.NewStringValue("7941778727260920248")},
+	{`unsign(hash.sip("bananas234029348"))`, value.NewStringValue("9314974731269371589")},
+
 	/*
 		Date functions
 	*/


### PR DESCRIPTION
This is a pretty specific use case, so feel free to let me know if there's a better approach here. I ran into this specifically because the sip hash function from (github.com/dchest/siphash) returns a `uint64`. Elsewhere in code we weren't converting the result to a signed `int64`. This allows us to keep the unsigned int result and return it as a string so as not to overflow the int64.

- `unsign(-794)` =>  "18446744073709550822"
- `unsign(794) => "794"
- `unsign(hash.sip("bananas234029348"))` => "9314974731269371589"
     - without `unsign()` the hash alone would return `-9131769342440180027`