### PR TITLE
lex: Do not swallow * after an identifier

### DIFF
--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -1496,9 +1496,7 @@ func lexIdentifierOfTypeNoWs(l *Lexer, shouldIgnore bool, forToken TokenType) St
 			return l.errorToken("identifier must begin with a letter " + string(l.input[l.start:l.pos]))
 		}
 
-		if r != '*' {
-			l.backup()
-		}
+		l.backup()
 
 		// Special case
 		//   content.`field name`

--- a/lex/lexer_test.go
+++ b/lex/lexer_test.go
@@ -98,6 +98,7 @@ func TestLexIdentity(t *testing.T) {
 	verifyIdentity(t, "`table_name`", "table_name", true)
 	verifyIdentity(t, "`table name`", "table name", true)
 	verifyIdentity(t, "`table name`.`right side`", "table name`.`right side", true)
+	verifyIdentity(t, `table_name*`, "table_name", true)
 	tok := token("`table_name`", LexIdentifier)
 	assert.True(t, tok.T == TokenIdentity && tok.V == "table_name", "%v", tok)
 	tok = token("`table w *&$% ^ 56 rty`", LexIdentifier)


### PR DESCRIPTION
The lexer currently absorbs a star right after an identifier.

It traces back to a `if r != "*"` conditional which doesn't seem to need to be there. Just removing it doesn't seem to break any test.