### PR TITLE
expr: Fix parsing of expressions with parenthesis

### DIFF
--- a/expr/parse.go
+++ b/expr/parse.go
@@ -147,6 +147,9 @@ func (m *LexTokenPager) Peek() lex.Token {
 	if m.cursor == -1 {
 		return m.tokens[1]
 	}
+	if m.cursor+1 > len(m.tokens) {
+		return eoft
+	}
 	return m.tokens[m.cursor+1]
 }
 

--- a/expr/parse_test.go
+++ b/expr/parse_test.go
@@ -196,6 +196,11 @@ var exprTests = []exprTest{
 		true,
 	},
 	{
+		`eq((1+1),2)`,
+		`eq((1 + 1), 2)`,
+		true,
+	},
+	{
 		`oneof("1",item,4)`,
 		`oneof("1", item, 4)`,
 		true,


### PR DESCRIPTION
The parser current crashes on expressions like:

```
SUM((a+b))
```

This is because it is trying to peek past the current stream of the lexer to generate debug messages, and the Peek() function doesn't handle that gracefully.